### PR TITLE
Type object fix in GET call

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,15 @@ Class | Method | HTTP request | Description
 *ListsApi* | [**updateList**](docs/Api/ListsApi.md#updatelist) | **PUT** /contacts/lists/{listId} | Update a list
 *ProcessApi* | [**getProcess**](docs/Api/ProcessApi.md#getprocess) | **GET** /processes/{processId} | Return the informations for a process
 *ProcessApi* | [**getProcesses**](docs/Api/ProcessApi.md#getprocesses) | **GET** /processes | Return all the processes for your account
-*ResellerApi* | [**addCredits**](docs/Api/ResellerApi.md#addcredits) | **POST** /reseller/children/{childId}/credits/add | Add Email and/or SMS credits to a specific child account
-*ResellerApi* | [**associateIpToChild**](docs/Api/ResellerApi.md#associateiptochild) | **POST** /reseller/children/{childId}/ips/associate | Associate a dedicated IP to the child
+*ResellerApi* | [**addCredits**](docs/Api/ResellerApi.md#addcredits) | **POST** /reseller/children/{childAuthKey}/credits/add | Add Email and/or SMS credits to a specific child account
+*ResellerApi* | [**associateIpToChild**](docs/Api/ResellerApi.md#associateiptochild) | **POST** /reseller/children/{childAuthKey}/ips/associate | Associate a dedicated IP to the child
 *ResellerApi* | [**createResellerChild**](docs/Api/ResellerApi.md#createresellerchild) | **POST** /reseller/children | Creates a reseller child
-*ResellerApi* | [**deleteResellerChild**](docs/Api/ResellerApi.md#deleteresellerchild) | **DELETE** /reseller/children/{childId} | Deletes a single reseller child based on the childId supplied
-*ResellerApi* | [**dissociateIpFromChild**](docs/Api/ResellerApi.md#dissociateipfromchild) | **POST** /reseller/children/{childId}/ips/dissociate | Dissociate a dedicated IP to the child
-*ResellerApi* | [**getChildInfo**](docs/Api/ResellerApi.md#getchildinfo) | **GET** /reseller/children/{childId} | Gets the info about a specific child account
+*ResellerApi* | [**deleteResellerChild**](docs/Api/ResellerApi.md#deleteresellerchild) | **DELETE** /reseller/children/{childAuthKey} | Deletes a single reseller child based on the childAuthKey supplied
+*ResellerApi* | [**dissociateIpFromChild**](docs/Api/ResellerApi.md#dissociateipfromchild) | **POST** /reseller/children/{childAuthKey}/ips/dissociate | Dissociate a dedicated IP to the child
+*ResellerApi* | [**getChildInfo**](docs/Api/ResellerApi.md#getchildinfo) | **GET** /reseller/children/{childAuthKey} | Gets the info about a specific child account
 *ResellerApi* | [**getResellerChilds**](docs/Api/ResellerApi.md#getresellerchilds) | **GET** /reseller/children | Gets the list of all reseller&#39;s children accounts
-*ResellerApi* | [**removeCredits**](docs/Api/ResellerApi.md#removecredits) | **POST** /reseller/children/{childId}/credits/remove | Remove Email and/or SMS credits from a specific child account
-*ResellerApi* | [**updateResellerChild**](docs/Api/ResellerApi.md#updateresellerchild) | **PUT** /reseller/children/{childId} | Updates infos of reseller&#39;s child based on the childId supplied
+*ResellerApi* | [**removeCredits**](docs/Api/ResellerApi.md#removecredits) | **POST** /reseller/children/{childAuthKey}/credits/remove | Remove Email and/or SMS credits from a specific child account
+*ResellerApi* | [**updateResellerChild**](docs/Api/ResellerApi.md#updateresellerchild) | **PUT** /reseller/children/{childAuthKey} | Updates infos of reseller&#39;s child based on the childAuthKey supplied
 *SMSCampaignsApi* | [**createSmsCampaign**](docs/Api/SMSCampaignsApi.md#createsmscampaign) | **POST** /smsCampaigns | Creates an SMS campaign
 *SMSCampaignsApi* | [**deleteSmsCampaign**](docs/Api/SMSCampaignsApi.md#deletesmscampaign) | **DELETE** /smsCampaigns/{campaignId} | Delete the SMS campaign
 *SMSCampaignsApi* | [**getSmsCampaign**](docs/Api/SMSCampaignsApi.md#getsmscampaign) | **GET** /smsCampaigns/{campaignId} | Get an SMS campaign
@@ -203,6 +203,7 @@ Class | Method | HTTP request | Description
  - [CreateEmailCampaignSender](docs/Model/CreateEmailCampaignSender.md)
  - [CreateList](docs/Model/CreateList.md)
  - [CreateModel](docs/Model/CreateModel.md)
+ - [CreateReseller](docs/Model/CreateReseller.md)
  - [CreateSender](docs/Model/CreateSender.md)
  - [CreateSenderIps](docs/Model/CreateSenderIps.md)
  - [CreateSenderModel](docs/Model/CreateSenderModel.md)
@@ -229,8 +230,9 @@ Class | Method | HTTP request | Description
  - [GetCampaignRecipients](docs/Model/GetCampaignRecipients.md)
  - [GetCampaignStats](docs/Model/GetCampaignStats.md)
  - [GetChildInfoApiKeys](docs/Model/GetChildInfoApiKeys.md)
+ - [GetChildInfoApiKeysV2](docs/Model/GetChildInfoApiKeysV2.md)
+ - [GetChildInfoApiKeysV3](docs/Model/GetChildInfoApiKeysV3.md)
  - [GetChildInfoCredits](docs/Model/GetChildInfoCredits.md)
- - [GetChildInfoIps](docs/Model/GetChildInfoIps.md)
  - [GetChildInfoStatistics](docs/Model/GetChildInfoStatistics.md)
  - [GetChildrenList](docs/Model/GetChildrenList.md)
  - [GetClient](docs/Model/GetClient.md)

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0.x-dev"
+            "dev-master": "5.0.x-dev"
         }
     }
 }

--- a/docs/Api/ResellerApi.md
+++ b/docs/Api/ResellerApi.md
@@ -4,19 +4,19 @@ All URIs are relative to *https://api.sendinblue.com/v3*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**addCredits**](ResellerApi.md#addCredits) | **POST** /reseller/children/{childId}/credits/add | Add Email and/or SMS credits to a specific child account
-[**associateIpToChild**](ResellerApi.md#associateIpToChild) | **POST** /reseller/children/{childId}/ips/associate | Associate a dedicated IP to the child
+[**addCredits**](ResellerApi.md#addCredits) | **POST** /reseller/children/{childAuthKey}/credits/add | Add Email and/or SMS credits to a specific child account
+[**associateIpToChild**](ResellerApi.md#associateIpToChild) | **POST** /reseller/children/{childAuthKey}/ips/associate | Associate a dedicated IP to the child
 [**createResellerChild**](ResellerApi.md#createResellerChild) | **POST** /reseller/children | Creates a reseller child
-[**deleteResellerChild**](ResellerApi.md#deleteResellerChild) | **DELETE** /reseller/children/{childId} | Deletes a single reseller child based on the childId supplied
-[**dissociateIpFromChild**](ResellerApi.md#dissociateIpFromChild) | **POST** /reseller/children/{childId}/ips/dissociate | Dissociate a dedicated IP to the child
-[**getChildInfo**](ResellerApi.md#getChildInfo) | **GET** /reseller/children/{childId} | Gets the info about a specific child account
+[**deleteResellerChild**](ResellerApi.md#deleteResellerChild) | **DELETE** /reseller/children/{childAuthKey} | Deletes a single reseller child based on the childAuthKey supplied
+[**dissociateIpFromChild**](ResellerApi.md#dissociateIpFromChild) | **POST** /reseller/children/{childAuthKey}/ips/dissociate | Dissociate a dedicated IP to the child
+[**getChildInfo**](ResellerApi.md#getChildInfo) | **GET** /reseller/children/{childAuthKey} | Gets the info about a specific child account
 [**getResellerChilds**](ResellerApi.md#getResellerChilds) | **GET** /reseller/children | Gets the list of all reseller&#39;s children accounts
-[**removeCredits**](ResellerApi.md#removeCredits) | **POST** /reseller/children/{childId}/credits/remove | Remove Email and/or SMS credits from a specific child account
-[**updateResellerChild**](ResellerApi.md#updateResellerChild) | **PUT** /reseller/children/{childId} | Updates infos of reseller&#39;s child based on the childId supplied
+[**removeCredits**](ResellerApi.md#removeCredits) | **POST** /reseller/children/{childAuthKey}/credits/remove | Remove Email and/or SMS credits from a specific child account
+[**updateResellerChild**](ResellerApi.md#updateResellerChild) | **PUT** /reseller/children/{childAuthKey} | Updates infos of reseller&#39;s child based on the childAuthKey supplied
 
 
 # **addCredits**
-> \SendinBlue\Client\Model\RemainingCreditModel addCredits($childId, $addCredits)
+> \SendinBlue\Client\Model\RemainingCreditModel addCredits($childAuthKey, $addCredits)
 
 Add Email and/or SMS credits to a specific child account
 
@@ -31,11 +31,11 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
 $addCredits = new \SendinBlue\Client\Model\AddCredits(); // \SendinBlue\Client\Model\AddCredits | Values to post to add credit to a specific child account
 
 try {
-    $result = $api_instance->addCredits($childId, $addCredits);
+    $result = $api_instance->addCredits($childAuthKey, $addCredits);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->addCredits: ', $e->getMessage(), PHP_EOL;
@@ -47,7 +47,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
  **addCredits** | [**\SendinBlue\Client\Model\AddCredits**](../Model/AddCredits.md)| Values to post to add credit to a specific child account |
 
 ### Return type
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **associateIpToChild**
-> associateIpToChild($childId, $ipId)
+> associateIpToChild($childAuthKey, $ip)
 
 Associate a dedicated IP to the child
 
@@ -81,11 +81,11 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
-$ipId = new \SendinBlue\Client\Model\ManageIp(); // \SendinBlue\Client\Model\ManageIp | IP's id
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
+$ip = new \SendinBlue\Client\Model\ManageIp(); // \SendinBlue\Client\Model\ManageIp | IP to associate
 
 try {
-    $api_instance->associateIpToChild($childId, $ipId);
+    $api_instance->associateIpToChild($childAuthKey, $ip);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->associateIpToChild: ', $e->getMessage(), PHP_EOL;
 }
@@ -96,8 +96,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
- **ipId** | [**\SendinBlue\Client\Model\ManageIp**](../Model/ManageIp.md)| IP&#39;s id |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
+ **ip** | [**\SendinBlue\Client\Model\ManageIp**](../Model/ManageIp.md)| IP to associate |
 
 ### Return type
 
@@ -115,7 +115,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **createResellerChild**
-> \SendinBlue\Client\Model\CreateModel createResellerChild($resellerChild)
+> \SendinBlue\Client\Model\CreateReseller createResellerChild($resellerChild)
 
 Creates a reseller child
 
@@ -149,7 +149,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**\SendinBlue\Client\Model\CreateModel**](../Model/CreateModel.md)
+[**\SendinBlue\Client\Model\CreateReseller**](../Model/CreateReseller.md)
 
 ### Authorization
 
@@ -163,9 +163,9 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **deleteResellerChild**
-> deleteResellerChild($childId)
+> deleteResellerChild($childAuthKey)
 
-Deletes a single reseller child based on the childId supplied
+Deletes a single reseller child based on the childAuthKey supplied
 
 ### Example
 ```php
@@ -178,10 +178,10 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
 
 try {
-    $api_instance->deleteResellerChild($childId);
+    $api_instance->deleteResellerChild($childAuthKey);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->deleteResellerChild: ', $e->getMessage(), PHP_EOL;
 }
@@ -192,7 +192,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
 
 ### Return type
 
@@ -210,7 +210,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **dissociateIpFromChild**
-> dissociateIpFromChild($childId, $ipId)
+> dissociateIpFromChild($childAuthKey, $ip)
 
 Dissociate a dedicated IP to the child
 
@@ -225,11 +225,11 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
-$ipId = new \SendinBlue\Client\Model\ManageIp(); // \SendinBlue\Client\Model\ManageIp | IP's id
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
+$ip = new \SendinBlue\Client\Model\ManageIp(); // \SendinBlue\Client\Model\ManageIp | IP to dissociate
 
 try {
-    $api_instance->dissociateIpFromChild($childId, $ipId);
+    $api_instance->dissociateIpFromChild($childAuthKey, $ip);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->dissociateIpFromChild: ', $e->getMessage(), PHP_EOL;
 }
@@ -240,8 +240,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
- **ipId** | [**\SendinBlue\Client\Model\ManageIp**](../Model/ManageIp.md)| IP&#39;s id |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
+ **ip** | [**\SendinBlue\Client\Model\ManageIp**](../Model/ManageIp.md)| IP to dissociate |
 
 ### Return type
 
@@ -259,7 +259,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getChildInfo**
-> \SendinBlue\Client\Model\GetChildInfo getChildInfo($childId)
+> \SendinBlue\Client\Model\GetChildInfo getChildInfo($childAuthKey)
 
 Gets the info about a specific child account
 
@@ -274,10 +274,10 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
 
 try {
-    $result = $api_instance->getChildInfo($childId);
+    $result = $api_instance->getChildInfo($childAuthKey);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->getChildInfo: ', $e->getMessage(), PHP_EOL;
@@ -289,7 +289,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
 
 ### Return type
 
@@ -351,7 +351,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **removeCredits**
-> \SendinBlue\Client\Model\RemainingCreditModel removeCredits($childId, $removeCredits)
+> \SendinBlue\Client\Model\RemainingCreditModel removeCredits($childAuthKey, $removeCredits)
 
 Remove Email and/or SMS credits from a specific child account
 
@@ -366,11 +366,11 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
 $removeCredits = new \SendinBlue\Client\Model\RemoveCredits(); // \SendinBlue\Client\Model\RemoveCredits | Values to post to remove email or SMS credits from a specific child account
 
 try {
-    $result = $api_instance->removeCredits($childId, $removeCredits);
+    $result = $api_instance->removeCredits($childAuthKey, $removeCredits);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->removeCredits: ', $e->getMessage(), PHP_EOL;
@@ -382,7 +382,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
  **removeCredits** | [**\SendinBlue\Client\Model\RemoveCredits**](../Model/RemoveCredits.md)| Values to post to remove email or SMS credits from a specific child account |
 
 ### Return type
@@ -401,9 +401,9 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **updateResellerChild**
-> updateResellerChild($childId, $resellerChild)
+> updateResellerChild($childAuthKey, $resellerChild)
 
-Updates infos of reseller's child based on the childId supplied
+Updates infos of reseller's child based on the childAuthKey supplied
 
 ### Example
 ```php
@@ -416,11 +416,11 @@ SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key',
 // SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
 
 $api_instance = new SendinBlue\Client\Api\ResellerApi();
-$childId = 789; // int | id of reseller's child
+$childAuthKey = "childAuthKey_example"; // string | auth key of reseller's child
 $resellerChild = new \SendinBlue\Client\Model\UpdateChild(); // \SendinBlue\Client\Model\UpdateChild | values to update in child profile
 
 try {
-    $api_instance->updateResellerChild($childId, $resellerChild);
+    $api_instance->updateResellerChild($childAuthKey, $resellerChild);
 } catch (Exception $e) {
     echo 'Exception when calling ResellerApi->updateResellerChild: ', $e->getMessage(), PHP_EOL;
 }
@@ -431,7 +431,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **childId** | **int**| id of reseller&#39;s child |
+ **childAuthKey** | **string**| auth key of reseller&#39;s child |
  **resellerChild** | [**\SendinBlue\Client\Model\UpdateChild**](../Model/UpdateChild.md)| values to update in child profile |
 
 ### Return type

--- a/docs/Model/CreateReseller.md
+++ b/docs/Model/CreateReseller.md
@@ -1,0 +1,10 @@
+# CreateReseller
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**authKey** | **string** | AuthKey of Reseller child created | 
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/GetChildInfoApiKeysV2.md
+++ b/docs/Model/GetChildInfoApiKeysV2.md
@@ -1,10 +1,10 @@
-# GetChildInfoIps
+# GetChildInfoApiKeysV2
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** | ID of the IP | 
-**ip** | **string** | IP associated to the child account user | 
+**name** | **string** | Name of the key for version 2 | 
+**key** | **string** | API Key for version 2 | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetChildInfoApiKeysV3.md
+++ b/docs/Model/GetChildInfoApiKeysV3.md
@@ -1,0 +1,11 @@
+# GetChildInfoApiKeysV3
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | **string** | Name of the key for version 3 | 
+**key** | **string** | API Key for version 3 | 
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/GetEmailCampaign.md
+++ b/docs/Model/GetEmailCampaign.md
@@ -23,6 +23,8 @@ Name | Type | Description | Notes
 **inlineImageActivation** | **bool** | Status of inline image. inlineImageActivation &#x3D; false means image can’t be embedded, &amp; inlineImageActivation &#x3D; true means image can be embedded, in the email. | [optional] 
 **mirrorActive** | **bool** | Status of mirror links in campaign. mirrorActive &#x3D; false means mirror links are deactivated, &amp; mirrorActive &#x3D; true means mirror links are activated, in the campaign | [optional] 
 **recurring** | **bool** | FOR TRIGGER ONLY ! Type of trigger campaign.recurring &#x3D; false means contact can receive the same Trigger campaign only once, &amp; recurring &#x3D; true means contact can receive the same Trigger campaign several times | [optional] 
+**recipients** | **object** |  | 
+**statistics** | **object** |  | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetSmsCampaign.md
+++ b/docs/Model/GetSmsCampaign.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 **sender** | **string** | Sender of the SMS Campaign | 
 **createdAt** | **\DateTime** | Creation UTC date-time of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **modifiedAt** | **\DateTime** | UTC date-time of last modification of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
+**recipients** | **object** |  | 
+**statistics** | **object** |  | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/lib/Api/ResellerApi.php
+++ b/lib/Api/ResellerApi.php
@@ -92,14 +92,14 @@ class ResellerApi
      *
      * Add Email and/or SMS credits to a specific child account
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @param \SendinBlue\Client\Model\AddCredits $addCredits Values to post to add credit to a specific child account (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return \SendinBlue\Client\Model\RemainingCreditModel
      */
-    public function addCredits($childId, $addCredits)
+    public function addCredits($childAuthKey, $addCredits)
     {
-        list($response) = $this->addCreditsWithHttpInfo($childId, $addCredits);
+        list($response) = $this->addCreditsWithHttpInfo($childAuthKey, $addCredits);
         return $response;
     }
 
@@ -108,23 +108,23 @@ class ResellerApi
      *
      * Add Email and/or SMS credits to a specific child account
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @param \SendinBlue\Client\Model\AddCredits $addCredits Values to post to add credit to a specific child account (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of \SendinBlue\Client\Model\RemainingCreditModel, HTTP status code, HTTP response headers (array of strings)
      */
-    public function addCreditsWithHttpInfo($childId, $addCredits)
+    public function addCreditsWithHttpInfo($childAuthKey, $addCredits)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling addCredits');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling addCredits');
         }
         // verify the required parameter 'addCredits' is set
         if ($addCredits === null) {
             throw new \InvalidArgumentException('Missing the required parameter $addCredits when calling addCredits');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}/credits/add";
+        $resourcePath = "/reseller/children/{childAuthKey}/credits/add";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -136,10 +136,10 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
@@ -169,7 +169,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 '\SendinBlue\Client\Model\RemainingCreditModel',
-                '/reseller/children/{childId}/credits/add'
+                '/reseller/children/{childAuthKey}/credits/add'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\SendinBlue\Client\Model\RemainingCreditModel', $httpHeader), $statusCode, $httpHeader];
@@ -202,14 +202,14 @@ class ResellerApi
      *
      * Associate a dedicated IP to the child
      *
-     * @param int $childId id of reseller&#39;s child (required)
-     * @param \SendinBlue\Client\Model\ManageIp $ipId IP&#39;s id (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
+     * @param \SendinBlue\Client\Model\ManageIp $ip IP to associate (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return void
      */
-    public function associateIpToChild($childId, $ipId)
+    public function associateIpToChild($childAuthKey, $ip)
     {
-        list($response) = $this->associateIpToChildWithHttpInfo($childId, $ipId);
+        list($response) = $this->associateIpToChildWithHttpInfo($childAuthKey, $ip);
         return $response;
     }
 
@@ -218,23 +218,23 @@ class ResellerApi
      *
      * Associate a dedicated IP to the child
      *
-     * @param int $childId id of reseller&#39;s child (required)
-     * @param \SendinBlue\Client\Model\ManageIp $ipId IP&#39;s id (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
+     * @param \SendinBlue\Client\Model\ManageIp $ip IP to associate (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function associateIpToChildWithHttpInfo($childId, $ipId)
+    public function associateIpToChildWithHttpInfo($childAuthKey, $ip)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling associateIpToChild');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling associateIpToChild');
         }
-        // verify the required parameter 'ipId' is set
-        if ($ipId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $ipId when calling associateIpToChild');
+        // verify the required parameter 'ip' is set
+        if ($ip === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $ip when calling associateIpToChild');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}/ips/associate";
+        $resourcePath = "/reseller/children/{childAuthKey}/ips/associate";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -246,17 +246,17 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
         // body params
         $_tempBody = null;
-        if (isset($ipId)) {
-            $_tempBody = $ipId;
+        if (isset($ip)) {
+            $_tempBody = $ip;
         }
 
         // for model (json/xml)
@@ -279,7 +279,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 null,
-                '/reseller/children/{childId}/ips/associate'
+                '/reseller/children/{childAuthKey}/ips/associate'
             );
 
             return [null, $statusCode, $httpHeader];
@@ -306,7 +306,7 @@ class ResellerApi
      *
      * @param \SendinBlue\Client\Model\CreateChild $resellerChild reseller child to add (optional)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
-     * @return \SendinBlue\Client\Model\CreateModel
+     * @return \SendinBlue\Client\Model\CreateReseller
      */
     public function createResellerChild($resellerChild = null)
     {
@@ -321,7 +321,7 @@ class ResellerApi
      *
      * @param \SendinBlue\Client\Model\CreateChild $resellerChild reseller child to add (optional)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
-     * @return array of \SendinBlue\Client\Model\CreateModel, HTTP status code, HTTP response headers (array of strings)
+     * @return array of \SendinBlue\Client\Model\CreateReseller, HTTP status code, HTTP response headers (array of strings)
      */
     public function createResellerChildWithHttpInfo($resellerChild = null)
     {
@@ -362,15 +362,15 @@ class ResellerApi
                 $queryParams,
                 $httpBody,
                 $headerParams,
-                '\SendinBlue\Client\Model\CreateModel',
+                '\SendinBlue\Client\Model\CreateReseller',
                 '/reseller/children'
             );
 
-            return [$this->apiClient->getSerializer()->deserialize($response, '\SendinBlue\Client\Model\CreateModel', $httpHeader), $statusCode, $httpHeader];
+            return [$this->apiClient->getSerializer()->deserialize($response, '\SendinBlue\Client\Model\CreateReseller', $httpHeader), $statusCode, $httpHeader];
         } catch (ApiException $e) {
             switch ($e->getCode()) {
                 case 201:
-                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\SendinBlue\Client\Model\CreateModel', $e->getResponseHeaders());
+                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\SendinBlue\Client\Model\CreateReseller', $e->getResponseHeaders());
                     $e->setResponseObject($data);
                     break;
                 case 400:
@@ -390,35 +390,35 @@ class ResellerApi
     /**
      * Operation deleteResellerChild
      *
-     * Deletes a single reseller child based on the childId supplied
+     * Deletes a single reseller child based on the childAuthKey supplied
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return void
      */
-    public function deleteResellerChild($childId)
+    public function deleteResellerChild($childAuthKey)
     {
-        list($response) = $this->deleteResellerChildWithHttpInfo($childId);
+        list($response) = $this->deleteResellerChildWithHttpInfo($childAuthKey);
         return $response;
     }
 
     /**
      * Operation deleteResellerChildWithHttpInfo
      *
-     * Deletes a single reseller child based on the childId supplied
+     * Deletes a single reseller child based on the childAuthKey supplied
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteResellerChildWithHttpInfo($childId)
+    public function deleteResellerChildWithHttpInfo($childAuthKey)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling deleteResellerChild');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling deleteResellerChild');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}";
+        $resourcePath = "/reseller/children/{childAuthKey}";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -430,10 +430,10 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
@@ -458,7 +458,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 null,
-                '/reseller/children/{childId}'
+                '/reseller/children/{childAuthKey}'
             );
 
             return [null, $statusCode, $httpHeader];
@@ -487,14 +487,14 @@ class ResellerApi
      *
      * Dissociate a dedicated IP to the child
      *
-     * @param int $childId id of reseller&#39;s child (required)
-     * @param \SendinBlue\Client\Model\ManageIp $ipId IP&#39;s id (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
+     * @param \SendinBlue\Client\Model\ManageIp $ip IP to dissociate (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return void
      */
-    public function dissociateIpFromChild($childId, $ipId)
+    public function dissociateIpFromChild($childAuthKey, $ip)
     {
-        list($response) = $this->dissociateIpFromChildWithHttpInfo($childId, $ipId);
+        list($response) = $this->dissociateIpFromChildWithHttpInfo($childAuthKey, $ip);
         return $response;
     }
 
@@ -503,23 +503,23 @@ class ResellerApi
      *
      * Dissociate a dedicated IP to the child
      *
-     * @param int $childId id of reseller&#39;s child (required)
-     * @param \SendinBlue\Client\Model\ManageIp $ipId IP&#39;s id (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
+     * @param \SendinBlue\Client\Model\ManageIp $ip IP to dissociate (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function dissociateIpFromChildWithHttpInfo($childId, $ipId)
+    public function dissociateIpFromChildWithHttpInfo($childAuthKey, $ip)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling dissociateIpFromChild');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling dissociateIpFromChild');
         }
-        // verify the required parameter 'ipId' is set
-        if ($ipId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $ipId when calling dissociateIpFromChild');
+        // verify the required parameter 'ip' is set
+        if ($ip === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $ip when calling dissociateIpFromChild');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}/ips/dissociate";
+        $resourcePath = "/reseller/children/{childAuthKey}/ips/dissociate";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -531,17 +531,17 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
         // body params
         $_tempBody = null;
-        if (isset($ipId)) {
-            $_tempBody = $ipId;
+        if (isset($ip)) {
+            $_tempBody = $ip;
         }
 
         // for model (json/xml)
@@ -564,7 +564,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 null,
-                '/reseller/children/{childId}/ips/dissociate'
+                '/reseller/children/{childAuthKey}/ips/dissociate'
             );
 
             return [null, $statusCode, $httpHeader];
@@ -589,13 +589,13 @@ class ResellerApi
      *
      * Gets the info about a specific child account
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return \SendinBlue\Client\Model\GetChildInfo
      */
-    public function getChildInfo($childId)
+    public function getChildInfo($childAuthKey)
     {
-        list($response) = $this->getChildInfoWithHttpInfo($childId);
+        list($response) = $this->getChildInfoWithHttpInfo($childAuthKey);
         return $response;
     }
 
@@ -604,18 +604,18 @@ class ResellerApi
      *
      * Gets the info about a specific child account
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of \SendinBlue\Client\Model\GetChildInfo, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getChildInfoWithHttpInfo($childId)
+    public function getChildInfoWithHttpInfo($childAuthKey)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling getChildInfo');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling getChildInfo');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}";
+        $resourcePath = "/reseller/children/{childAuthKey}";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -627,10 +627,10 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
@@ -655,7 +655,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 '\SendinBlue\Client\Model\GetChildInfo',
-                '/reseller/children/{childId}'
+                '/reseller/children/{childAuthKey}'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\SendinBlue\Client\Model\GetChildInfo', $httpHeader), $statusCode, $httpHeader];
@@ -765,14 +765,14 @@ class ResellerApi
      *
      * Remove Email and/or SMS credits from a specific child account
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @param \SendinBlue\Client\Model\RemoveCredits $removeCredits Values to post to remove email or SMS credits from a specific child account (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return \SendinBlue\Client\Model\RemainingCreditModel
      */
-    public function removeCredits($childId, $removeCredits)
+    public function removeCredits($childAuthKey, $removeCredits)
     {
-        list($response) = $this->removeCreditsWithHttpInfo($childId, $removeCredits);
+        list($response) = $this->removeCreditsWithHttpInfo($childAuthKey, $removeCredits);
         return $response;
     }
 
@@ -781,23 +781,23 @@ class ResellerApi
      *
      * Remove Email and/or SMS credits from a specific child account
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @param \SendinBlue\Client\Model\RemoveCredits $removeCredits Values to post to remove email or SMS credits from a specific child account (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of \SendinBlue\Client\Model\RemainingCreditModel, HTTP status code, HTTP response headers (array of strings)
      */
-    public function removeCreditsWithHttpInfo($childId, $removeCredits)
+    public function removeCreditsWithHttpInfo($childAuthKey, $removeCredits)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling removeCredits');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling removeCredits');
         }
         // verify the required parameter 'removeCredits' is set
         if ($removeCredits === null) {
             throw new \InvalidArgumentException('Missing the required parameter $removeCredits when calling removeCredits');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}/credits/remove";
+        $resourcePath = "/reseller/children/{childAuthKey}/credits/remove";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -809,10 +809,10 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
@@ -842,7 +842,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 '\SendinBlue\Client\Model\RemainingCreditModel',
-                '/reseller/children/{childId}/credits/remove'
+                '/reseller/children/{childAuthKey}/credits/remove'
             );
 
             return [$this->apiClient->getSerializer()->deserialize($response, '\SendinBlue\Client\Model\RemainingCreditModel', $httpHeader), $statusCode, $httpHeader];
@@ -873,41 +873,41 @@ class ResellerApi
     /**
      * Operation updateResellerChild
      *
-     * Updates infos of reseller's child based on the childId supplied
+     * Updates infos of reseller's child based on the childAuthKey supplied
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @param \SendinBlue\Client\Model\UpdateChild $resellerChild values to update in child profile (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return void
      */
-    public function updateResellerChild($childId, $resellerChild)
+    public function updateResellerChild($childAuthKey, $resellerChild)
     {
-        list($response) = $this->updateResellerChildWithHttpInfo($childId, $resellerChild);
+        list($response) = $this->updateResellerChildWithHttpInfo($childAuthKey, $resellerChild);
         return $response;
     }
 
     /**
      * Operation updateResellerChildWithHttpInfo
      *
-     * Updates infos of reseller's child based on the childId supplied
+     * Updates infos of reseller's child based on the childAuthKey supplied
      *
-     * @param int $childId id of reseller&#39;s child (required)
+     * @param string $childAuthKey auth key of reseller&#39;s child (required)
      * @param \SendinBlue\Client\Model\UpdateChild $resellerChild values to update in child profile (required)
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updateResellerChildWithHttpInfo($childId, $resellerChild)
+    public function updateResellerChildWithHttpInfo($childAuthKey, $resellerChild)
     {
-        // verify the required parameter 'childId' is set
-        if ($childId === null) {
-            throw new \InvalidArgumentException('Missing the required parameter $childId when calling updateResellerChild');
+        // verify the required parameter 'childAuthKey' is set
+        if ($childAuthKey === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $childAuthKey when calling updateResellerChild');
         }
         // verify the required parameter 'resellerChild' is set
         if ($resellerChild === null) {
             throw new \InvalidArgumentException('Missing the required parameter $resellerChild when calling updateResellerChild');
         }
         // parse inputs
-        $resourcePath = "/reseller/children/{childId}";
+        $resourcePath = "/reseller/children/{childAuthKey}";
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -919,10 +919,10 @@ class ResellerApi
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
         // path params
-        if ($childId !== null) {
+        if ($childAuthKey !== null) {
             $resourcePath = str_replace(
-                "{" . "childId" . "}",
-                $this->apiClient->getSerializer()->toPathValue($childId),
+                "{" . "childAuthKey" . "}",
+                $this->apiClient->getSerializer()->toPathValue($childAuthKey),
                 $resourcePath
             );
         }
@@ -952,7 +952,7 @@ class ResellerApi
                 $httpBody,
                 $headerParams,
                 null,
-                '/reseller/children/{childId}'
+                '/reseller/children/{childAuthKey}'
             );
 
             return [null, $statusCode, $httpHeader];

--- a/lib/Model/AddCredits.php
+++ b/lib/Model/AddCredits.php
@@ -177,7 +177,7 @@ class AddCredits implements ArrayAccess
 
     /**
      * Sets sms
-     * @param int $sms SMS credits to be added to the child account
+     * @param int $sms Required if email credits are empty. SMS credits to be added to the child account
      * @return $this
      */
     public function setSms($sms)
@@ -198,7 +198,7 @@ class AddCredits implements ArrayAccess
 
     /**
      * Sets email
-     * @param int $email Email credits to be added to the child account
+     * @param int $email Required if sms credits are empty. Email credits to be added to the child account
      * @return $this
      */
     public function setEmail($email)

--- a/lib/Model/CreateReseller.php
+++ b/lib/Model/CreateReseller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * GetChildInfoIps
+ * CreateReseller
  *
  * PHP version 5
  *
@@ -32,14 +32,14 @@ namespace SendinBlue\Client\Model;
 use \ArrayAccess;
 
 /**
- * GetChildInfoIps Class Doc Comment
+ * CreateReseller Class Doc Comment
  *
  * @category    Class
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class GetChildInfoIps implements ArrayAccess
+class CreateReseller implements ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -47,15 +47,14 @@ class GetChildInfoIps implements ArrayAccess
       * The original name of the model.
       * @var string
       */
-    protected static $swaggerModelName = 'getChildInfo_ips';
+    protected static $swaggerModelName = 'createReseller';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'id' => 'int',
-        'ip' => 'string'
+        'authKey' => 'string'
     ];
 
     /**
@@ -63,8 +62,7 @@ class GetChildInfoIps implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'id' => 'int64',
-        'ip' => 'ip'
+        'authKey' => null
     ];
 
     public static function swaggerTypes()
@@ -82,8 +80,7 @@ class GetChildInfoIps implements ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'id' => 'id',
-        'ip' => 'ip'
+        'authKey' => 'authKey'
     ];
 
 
@@ -92,8 +89,7 @@ class GetChildInfoIps implements ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'id' => 'setId',
-        'ip' => 'setIp'
+        'authKey' => 'setAuthKey'
     ];
 
 
@@ -102,8 +98,7 @@ class GetChildInfoIps implements ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'id' => 'getId',
-        'ip' => 'getIp'
+        'authKey' => 'getAuthKey'
     ];
 
     public static function attributeMap()
@@ -137,8 +132,7 @@ class GetChildInfoIps implements ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
-        $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
+        $this->container['authKey'] = isset($data['authKey']) ? $data['authKey'] : null;
     }
 
     /**
@@ -150,11 +144,8 @@ class GetChildInfoIps implements ArrayAccess
     {
         $invalid_properties = [];
 
-        if ($this->container['id'] === null) {
-            $invalid_properties[] = "'id' can't be null";
-        }
-        if ($this->container['ip'] === null) {
-            $invalid_properties[] = "'ip' can't be null";
+        if ($this->container['authKey'] === null) {
+            $invalid_properties[] = "'authKey' can't be null";
         }
         return $invalid_properties;
     }
@@ -168,10 +159,7 @@ class GetChildInfoIps implements ArrayAccess
     public function valid()
     {
 
-        if ($this->container['id'] === null) {
-            return false;
-        }
-        if ($this->container['ip'] === null) {
+        if ($this->container['authKey'] === null) {
             return false;
         }
         return true;
@@ -179,43 +167,22 @@ class GetChildInfoIps implements ArrayAccess
 
 
     /**
-     * Gets id
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->container['id'];
-    }
-
-    /**
-     * Sets id
-     * @param int $id ID of the IP
-     * @return $this
-     */
-    public function setId($id)
-    {
-        $this->container['id'] = $id;
-
-        return $this;
-    }
-
-    /**
-     * Gets ip
+     * Gets authKey
      * @return string
      */
-    public function getIp()
+    public function getAuthKey()
     {
-        return $this->container['ip'];
+        return $this->container['authKey'];
     }
 
     /**
-     * Sets ip
-     * @param string $ip IP associated to the child account user
+     * Sets authKey
+     * @param string $authKey AuthKey of Reseller child created
      * @return $this
      */
-    public function setIp($ip)
+    public function setAuthKey($authKey)
     {
-        $this->container['ip'] = $ip;
+        $this->container['authKey'] = $authKey;
 
         return $this;
     }

--- a/lib/Model/GetChildInfo.php
+++ b/lib/Model/GetChildInfo.php
@@ -61,8 +61,8 @@ class GetChildInfo implements ArrayAccess
         'credits' => '\SendinBlue\Client\Model\GetChildInfoCredits',
         'statistics' => '\SendinBlue\Client\Model\GetChildInfoStatistics',
         'password' => 'string',
-        'ips' => '\SendinBlue\Client\Model\GetChildInfoIps[]',
-        'apiKeys' => '\SendinBlue\Client\Model\GetChildInfoApiKeys[]'
+        'ips' => 'string[]',
+        'apiKeys' => '\SendinBlue\Client\Model\GetChildInfoApiKeys'
     ];
 
     /**
@@ -387,7 +387,7 @@ class GetChildInfo implements ArrayAccess
 
     /**
      * Gets ips
-     * @return \SendinBlue\Client\Model\GetChildInfoIps[]
+     * @return string[]
      */
     public function getIps()
     {
@@ -396,7 +396,7 @@ class GetChildInfo implements ArrayAccess
 
     /**
      * Sets ips
-     * @param \SendinBlue\Client\Model\GetChildInfoIps[] $ips IP(s) associated to a child account user
+     * @param string[] $ips IP(s) associated to a child account user
      * @return $this
      */
     public function setIps($ips)
@@ -408,7 +408,7 @@ class GetChildInfo implements ArrayAccess
 
     /**
      * Gets apiKeys
-     * @return \SendinBlue\Client\Model\GetChildInfoApiKeys[]
+     * @return \SendinBlue\Client\Model\GetChildInfoApiKeys
      */
     public function getApiKeys()
     {
@@ -417,7 +417,7 @@ class GetChildInfo implements ArrayAccess
 
     /**
      * Sets apiKeys
-     * @param \SendinBlue\Client\Model\GetChildInfoApiKeys[] $apiKeys API Keys associated to child account
+     * @param \SendinBlue\Client\Model\GetChildInfoApiKeys $apiKeys
      * @return $this
      */
     public function setApiKeys($apiKeys)

--- a/lib/Model/GetChildInfoApiKeys.php
+++ b/lib/Model/GetChildInfoApiKeys.php
@@ -35,6 +35,7 @@ use \ArrayAccess;
  * GetChildInfoApiKeys Class Doc Comment
  *
  * @category    Class
+ * @description API Keys associated to child account
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
@@ -54,9 +55,8 @@ class GetChildInfoApiKeys implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'name' => 'string',
-        'key' => 'string',
-        'secret' => 'string'
+        'v2' => '\SendinBlue\Client\Model\GetChildInfoApiKeysV2[]',
+        'v3' => '\SendinBlue\Client\Model\GetChildInfoApiKeysV3[]'
     ];
 
     /**
@@ -64,9 +64,8 @@ class GetChildInfoApiKeys implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'name' => null,
-        'key' => null,
-        'secret' => null
+        'v2' => null,
+        'v3' => null
     ];
 
     public static function swaggerTypes()
@@ -84,9 +83,8 @@ class GetChildInfoApiKeys implements ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name',
-        'key' => 'key',
-        'secret' => 'secret'
+        'v2' => 'v2',
+        'v3' => 'v3'
     ];
 
 
@@ -95,9 +93,8 @@ class GetChildInfoApiKeys implements ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName',
-        'key' => 'setKey',
-        'secret' => 'setSecret'
+        'v2' => 'setV2',
+        'v3' => 'setV3'
     ];
 
 
@@ -106,9 +103,8 @@ class GetChildInfoApiKeys implements ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName',
-        'key' => 'getKey',
-        'secret' => 'getSecret'
+        'v2' => 'getV2',
+        'v3' => 'getV3'
     ];
 
     public static function attributeMap()
@@ -142,9 +138,8 @@ class GetChildInfoApiKeys implements ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['key'] = isset($data['key']) ? $data['key'] : null;
-        $this->container['secret'] = isset($data['secret']) ? $data['secret'] : null;
+        $this->container['v2'] = isset($data['v2']) ? $data['v2'] : null;
+        $this->container['v3'] = isset($data['v3']) ? $data['v3'] : null;
     }
 
     /**
@@ -156,11 +151,8 @@ class GetChildInfoApiKeys implements ArrayAccess
     {
         $invalid_properties = [];
 
-        if ($this->container['name'] === null) {
-            $invalid_properties[] = "'name' can't be null";
-        }
-        if ($this->container['key'] === null) {
-            $invalid_properties[] = "'key' can't be null";
+        if ($this->container['v2'] === null) {
+            $invalid_properties[] = "'v2' can't be null";
         }
         return $invalid_properties;
     }
@@ -174,10 +166,7 @@ class GetChildInfoApiKeys implements ArrayAccess
     public function valid()
     {
 
-        if ($this->container['name'] === null) {
-            return false;
-        }
-        if ($this->container['key'] === null) {
+        if ($this->container['v2'] === null) {
             return false;
         }
         return true;
@@ -185,64 +174,43 @@ class GetChildInfoApiKeys implements ArrayAccess
 
 
     /**
-     * Gets name
-     * @return string
+     * Gets v2
+     * @return \SendinBlue\Client\Model\GetChildInfoApiKeysV2[]
      */
-    public function getName()
+    public function getV2()
     {
-        return $this->container['name'];
+        return $this->container['v2'];
     }
 
     /**
-     * Sets name
-     * @param string $name Name of the key
+     * Sets v2
+     * @param \SendinBlue\Client\Model\GetChildInfoApiKeysV2[] $v2
      * @return $this
      */
-    public function setName($name)
+    public function setV2($v2)
     {
-        $this->container['name'] = $name;
+        $this->container['v2'] = $v2;
 
         return $this;
     }
 
     /**
-     * Gets key
-     * @return string
+     * Gets v3
+     * @return \SendinBlue\Client\Model\GetChildInfoApiKeysV3[]
      */
-    public function getKey()
+    public function getV3()
     {
-        return $this->container['key'];
+        return $this->container['v3'];
     }
 
     /**
-     * Sets key
-     * @param string $key API Key
+     * Sets v3
+     * @param \SendinBlue\Client\Model\GetChildInfoApiKeysV3[] $v3
      * @return $this
      */
-    public function setKey($key)
+    public function setV3($v3)
     {
-        $this->container['key'] = $key;
-
-        return $this;
-    }
-
-    /**
-     * Gets secret
-     * @return string
-     */
-    public function getSecret()
-    {
-        return $this->container['secret'];
-    }
-
-    /**
-     * Sets secret
-     * @param string $secret Secret Key associated to the API Key (in case v1 Key is used only)
-     * @return $this
-     */
-    public function setSecret($secret)
-    {
-        $this->container['secret'] = $secret;
+        $this->container['v3'] = $v3;
 
         return $this;
     }

--- a/lib/Model/GetChildInfoApiKeysV2.php
+++ b/lib/Model/GetChildInfoApiKeysV2.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ErrorModel
+ * GetChildInfoApiKeysV2
  *
  * PHP version 5
  *
@@ -32,14 +32,14 @@ namespace SendinBlue\Client\Model;
 use \ArrayAccess;
 
 /**
- * ErrorModel Class Doc Comment
+ * GetChildInfoApiKeysV2 Class Doc Comment
  *
  * @category    Class
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class ErrorModel implements ArrayAccess
+class GetChildInfoApiKeysV2 implements ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -47,15 +47,15 @@ class ErrorModel implements ArrayAccess
       * The original name of the model.
       * @var string
       */
-    protected static $swaggerModelName = 'errorModel';
+    protected static $swaggerModelName = 'getChildInfo_apiKeys_v2';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'code' => 'string',
-        'message' => 'string'
+        'name' => 'string',
+        'key' => 'string'
     ];
 
     /**
@@ -63,8 +63,8 @@ class ErrorModel implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'code' => null,
-        'message' => null
+        'name' => null,
+        'key' => null
     ];
 
     public static function swaggerTypes()
@@ -82,8 +82,8 @@ class ErrorModel implements ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'code' => 'code',
-        'message' => 'message'
+        'name' => 'name',
+        'key' => 'key'
     ];
 
 
@@ -92,8 +92,8 @@ class ErrorModel implements ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'code' => 'setCode',
-        'message' => 'setMessage'
+        'name' => 'setName',
+        'key' => 'setKey'
     ];
 
 
@@ -102,8 +102,8 @@ class ErrorModel implements ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'code' => 'getCode',
-        'message' => 'getMessage'
+        'name' => 'getName',
+        'key' => 'getKey'
     ];
 
     public static function attributeMap()
@@ -121,48 +121,8 @@ class ErrorModel implements ArrayAccess
         return self::$getters;
     }
 
-    const CODE_INVALID_PARAMETER = 'invalid_parameter';
-    const CODE_MISSING_PARAMETER = 'missing_parameter';
-    const CODE_OUT_OF_RANGE = 'out_of_range';
-    const CODE_CAMPAIGN_PROCESSING = 'campaign_processing';
-    const CODE_CAMPAIGN_SENT = 'campaign_sent';
-    const CODE_DOCUMENT_NOT_FOUND = 'document_not_found';
-    const CODE_RESELLER_PERMISSION_DENIED = 'reseller_permission_denied';
-    const CODE_NOT_ENOUGH_CREDITS = 'not_enough_credits';
-    const CODE_PERMISSION_DENIED = 'permission_denied';
-    const CODE_DUPLICATE_PARAMETER = 'duplicate_parameter';
-    const CODE_DUPLICATE_REQUEST = 'duplicate_request';
-    const CODE_METHOD_NOT_ALLOWED = 'method_not_allowed';
-    const CODE_UNAUTHORIZED = 'unauthorized';
-    const CODE_ACCOUNT_UNDER_VALIDATION = 'account_under_validation';
-    const CODE_NOT_ACCEPTABLE = 'not_acceptable';
     
 
-    
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public function getCodeAllowableValues()
-    {
-        return [
-            self::CODE_INVALID_PARAMETER,
-            self::CODE_MISSING_PARAMETER,
-            self::CODE_OUT_OF_RANGE,
-            self::CODE_CAMPAIGN_PROCESSING,
-            self::CODE_CAMPAIGN_SENT,
-            self::CODE_DOCUMENT_NOT_FOUND,
-            self::CODE_RESELLER_PERMISSION_DENIED,
-            self::CODE_NOT_ENOUGH_CREDITS,
-            self::CODE_PERMISSION_DENIED,
-            self::CODE_DUPLICATE_PARAMETER,
-            self::CODE_DUPLICATE_REQUEST,
-            self::CODE_METHOD_NOT_ALLOWED,
-            self::CODE_UNAUTHORIZED,
-            self::CODE_ACCOUNT_UNDER_VALIDATION,
-            self::CODE_NOT_ACCEPTABLE,
-        ];
-    }
     
 
     /**
@@ -177,8 +137,8 @@ class ErrorModel implements ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['code'] = isset($data['code']) ? $data['code'] : null;
-        $this->container['message'] = isset($data['message']) ? $data['message'] : null;
+        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
+        $this->container['key'] = isset($data['key']) ? $data['key'] : null;
     }
 
     /**
@@ -190,19 +150,11 @@ class ErrorModel implements ArrayAccess
     {
         $invalid_properties = [];
 
-        if ($this->container['code'] === null) {
-            $invalid_properties[] = "'code' can't be null";
+        if ($this->container['name'] === null) {
+            $invalid_properties[] = "'name' can't be null";
         }
-        $allowed_values = $this->getCodeAllowableValues();
-        if (!in_array($this->container['code'], $allowed_values)) {
-            $invalid_properties[] = sprintf(
-                "invalid value for 'code', must be one of '%s'",
-                implode("', '", $allowed_values)
-            );
-        }
-
-        if ($this->container['message'] === null) {
-            $invalid_properties[] = "'message' can't be null";
+        if ($this->container['key'] === null) {
+            $invalid_properties[] = "'key' can't be null";
         }
         return $invalid_properties;
     }
@@ -216,14 +168,10 @@ class ErrorModel implements ArrayAccess
     public function valid()
     {
 
-        if ($this->container['code'] === null) {
+        if ($this->container['name'] === null) {
             return false;
         }
-        $allowed_values = $this->getCodeAllowableValues();
-        if (!in_array($this->container['code'], $allowed_values)) {
-            return false;
-        }
-        if ($this->container['message'] === null) {
+        if ($this->container['key'] === null) {
             return false;
         }
         return true;
@@ -231,52 +179,43 @@ class ErrorModel implements ArrayAccess
 
 
     /**
-     * Gets code
+     * Gets name
      * @return string
      */
-    public function getCode()
+    public function getName()
     {
-        return $this->container['code'];
+        return $this->container['name'];
     }
 
     /**
-     * Sets code
-     * @param string $code Error code displayed in case of a failure
+     * Sets name
+     * @param string $name Name of the key for version 2
      * @return $this
      */
-    public function setCode($code)
+    public function setName($name)
     {
-        $allowed_values = $this->getCodeAllowableValues();
-        if (!in_array($code, $allowed_values)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value for 'code', must be one of '%s'",
-                    implode("', '", $allowed_values)
-                )
-            );
-        }
-        $this->container['code'] = $code;
+        $this->container['name'] = $name;
 
         return $this;
     }
 
     /**
-     * Gets message
+     * Gets key
      * @return string
      */
-    public function getMessage()
+    public function getKey()
     {
-        return $this->container['message'];
+        return $this->container['key'];
     }
 
     /**
-     * Sets message
-     * @param string $message Readable message associated to the failure
+     * Sets key
+     * @param string $key API Key for version 2
      * @return $this
      */
-    public function setMessage($message)
+    public function setKey($key)
     {
-        $this->container['message'] = $message;
+        $this->container['key'] = $key;
 
         return $this;
     }

--- a/lib/Model/GetChildInfoApiKeysV3.php
+++ b/lib/Model/GetChildInfoApiKeysV3.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ErrorModel
+ * GetChildInfoApiKeysV3
  *
  * PHP version 5
  *
@@ -32,14 +32,14 @@ namespace SendinBlue\Client\Model;
 use \ArrayAccess;
 
 /**
- * ErrorModel Class Doc Comment
+ * GetChildInfoApiKeysV3 Class Doc Comment
  *
  * @category    Class
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class ErrorModel implements ArrayAccess
+class GetChildInfoApiKeysV3 implements ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -47,15 +47,15 @@ class ErrorModel implements ArrayAccess
       * The original name of the model.
       * @var string
       */
-    protected static $swaggerModelName = 'errorModel';
+    protected static $swaggerModelName = 'getChildInfo_apiKeys_v3';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'code' => 'string',
-        'message' => 'string'
+        'name' => 'string',
+        'key' => 'string'
     ];
 
     /**
@@ -63,8 +63,8 @@ class ErrorModel implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'code' => null,
-        'message' => null
+        'name' => null,
+        'key' => null
     ];
 
     public static function swaggerTypes()
@@ -82,8 +82,8 @@ class ErrorModel implements ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'code' => 'code',
-        'message' => 'message'
+        'name' => 'name',
+        'key' => 'key'
     ];
 
 
@@ -92,8 +92,8 @@ class ErrorModel implements ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'code' => 'setCode',
-        'message' => 'setMessage'
+        'name' => 'setName',
+        'key' => 'setKey'
     ];
 
 
@@ -102,8 +102,8 @@ class ErrorModel implements ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'code' => 'getCode',
-        'message' => 'getMessage'
+        'name' => 'getName',
+        'key' => 'getKey'
     ];
 
     public static function attributeMap()
@@ -121,48 +121,8 @@ class ErrorModel implements ArrayAccess
         return self::$getters;
     }
 
-    const CODE_INVALID_PARAMETER = 'invalid_parameter';
-    const CODE_MISSING_PARAMETER = 'missing_parameter';
-    const CODE_OUT_OF_RANGE = 'out_of_range';
-    const CODE_CAMPAIGN_PROCESSING = 'campaign_processing';
-    const CODE_CAMPAIGN_SENT = 'campaign_sent';
-    const CODE_DOCUMENT_NOT_FOUND = 'document_not_found';
-    const CODE_RESELLER_PERMISSION_DENIED = 'reseller_permission_denied';
-    const CODE_NOT_ENOUGH_CREDITS = 'not_enough_credits';
-    const CODE_PERMISSION_DENIED = 'permission_denied';
-    const CODE_DUPLICATE_PARAMETER = 'duplicate_parameter';
-    const CODE_DUPLICATE_REQUEST = 'duplicate_request';
-    const CODE_METHOD_NOT_ALLOWED = 'method_not_allowed';
-    const CODE_UNAUTHORIZED = 'unauthorized';
-    const CODE_ACCOUNT_UNDER_VALIDATION = 'account_under_validation';
-    const CODE_NOT_ACCEPTABLE = 'not_acceptable';
     
 
-    
-    /**
-     * Gets allowable values of the enum
-     * @return string[]
-     */
-    public function getCodeAllowableValues()
-    {
-        return [
-            self::CODE_INVALID_PARAMETER,
-            self::CODE_MISSING_PARAMETER,
-            self::CODE_OUT_OF_RANGE,
-            self::CODE_CAMPAIGN_PROCESSING,
-            self::CODE_CAMPAIGN_SENT,
-            self::CODE_DOCUMENT_NOT_FOUND,
-            self::CODE_RESELLER_PERMISSION_DENIED,
-            self::CODE_NOT_ENOUGH_CREDITS,
-            self::CODE_PERMISSION_DENIED,
-            self::CODE_DUPLICATE_PARAMETER,
-            self::CODE_DUPLICATE_REQUEST,
-            self::CODE_METHOD_NOT_ALLOWED,
-            self::CODE_UNAUTHORIZED,
-            self::CODE_ACCOUNT_UNDER_VALIDATION,
-            self::CODE_NOT_ACCEPTABLE,
-        ];
-    }
     
 
     /**
@@ -177,8 +137,8 @@ class ErrorModel implements ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['code'] = isset($data['code']) ? $data['code'] : null;
-        $this->container['message'] = isset($data['message']) ? $data['message'] : null;
+        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
+        $this->container['key'] = isset($data['key']) ? $data['key'] : null;
     }
 
     /**
@@ -190,19 +150,11 @@ class ErrorModel implements ArrayAccess
     {
         $invalid_properties = [];
 
-        if ($this->container['code'] === null) {
-            $invalid_properties[] = "'code' can't be null";
+        if ($this->container['name'] === null) {
+            $invalid_properties[] = "'name' can't be null";
         }
-        $allowed_values = $this->getCodeAllowableValues();
-        if (!in_array($this->container['code'], $allowed_values)) {
-            $invalid_properties[] = sprintf(
-                "invalid value for 'code', must be one of '%s'",
-                implode("', '", $allowed_values)
-            );
-        }
-
-        if ($this->container['message'] === null) {
-            $invalid_properties[] = "'message' can't be null";
+        if ($this->container['key'] === null) {
+            $invalid_properties[] = "'key' can't be null";
         }
         return $invalid_properties;
     }
@@ -216,14 +168,10 @@ class ErrorModel implements ArrayAccess
     public function valid()
     {
 
-        if ($this->container['code'] === null) {
+        if ($this->container['name'] === null) {
             return false;
         }
-        $allowed_values = $this->getCodeAllowableValues();
-        if (!in_array($this->container['code'], $allowed_values)) {
-            return false;
-        }
-        if ($this->container['message'] === null) {
+        if ($this->container['key'] === null) {
             return false;
         }
         return true;
@@ -231,52 +179,43 @@ class ErrorModel implements ArrayAccess
 
 
     /**
-     * Gets code
+     * Gets name
      * @return string
      */
-    public function getCode()
+    public function getName()
     {
-        return $this->container['code'];
+        return $this->container['name'];
     }
 
     /**
-     * Sets code
-     * @param string $code Error code displayed in case of a failure
+     * Sets name
+     * @param string $name Name of the key for version 3
      * @return $this
      */
-    public function setCode($code)
+    public function setName($name)
     {
-        $allowed_values = $this->getCodeAllowableValues();
-        if (!in_array($code, $allowed_values)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value for 'code', must be one of '%s'",
-                    implode("', '", $allowed_values)
-                )
-            );
-        }
-        $this->container['code'] = $code;
+        $this->container['name'] = $name;
 
         return $this;
     }
 
     /**
-     * Gets message
+     * Gets key
      * @return string
      */
-    public function getMessage()
+    public function getKey()
     {
-        return $this->container['message'];
+        return $this->container['key'];
     }
 
     /**
-     * Sets message
-     * @param string $message Readable message associated to the failure
+     * Sets key
+     * @param string $key API Key for version 3
      * @return $this
      */
-    public function setMessage($message)
+    public function setKey($key)
     {
-        $this->container['message'] = $message;
+        $this->container['key'] = $key;
 
         return $this;
     }

--- a/lib/Model/GetEmailCampaign.php
+++ b/lib/Model/GetEmailCampaign.php
@@ -73,7 +73,9 @@ class GetEmailCampaign implements ArrayAccess
         'modifiedAt' => '\DateTime',
         'inlineImageActivation' => 'bool',
         'mirrorActive' => 'bool',
-        'recurring' => 'bool'
+        'recurring' => 'bool',
+        'recipients' => 'object',
+        'statistics' => 'object'
     ];
 
     /**
@@ -100,7 +102,9 @@ class GetEmailCampaign implements ArrayAccess
         'modifiedAt' => 'date-time',
         'inlineImageActivation' => null,
         'mirrorActive' => null,
-        'recurring' => null
+        'recurring' => null,
+        'recipients' => null,
+        'statistics' => null
     ];
 
     public static function swaggerTypes()
@@ -137,7 +141,9 @@ class GetEmailCampaign implements ArrayAccess
         'modifiedAt' => 'modifiedAt',
         'inlineImageActivation' => 'inlineImageActivation',
         'mirrorActive' => 'mirrorActive',
-        'recurring' => 'recurring'
+        'recurring' => 'recurring',
+        'recipients' => 'recipients',
+        'statistics' => 'statistics'
     ];
 
 
@@ -165,7 +171,9 @@ class GetEmailCampaign implements ArrayAccess
         'modifiedAt' => 'setModifiedAt',
         'inlineImageActivation' => 'setInlineImageActivation',
         'mirrorActive' => 'setMirrorActive',
-        'recurring' => 'setRecurring'
+        'recurring' => 'setRecurring',
+        'recipients' => 'setRecipients',
+        'statistics' => 'setStatistics'
     ];
 
 
@@ -193,7 +201,9 @@ class GetEmailCampaign implements ArrayAccess
         'modifiedAt' => 'getModifiedAt',
         'inlineImageActivation' => 'getInlineImageActivation',
         'mirrorActive' => 'getMirrorActive',
-        'recurring' => 'getRecurring'
+        'recurring' => 'getRecurring',
+        'recipients' => 'getRecipients',
+        'statistics' => 'getStatistics'
     ];
 
     public static function attributeMap()
@@ -283,6 +293,8 @@ class GetEmailCampaign implements ArrayAccess
         $this->container['inlineImageActivation'] = isset($data['inlineImageActivation']) ? $data['inlineImageActivation'] : null;
         $this->container['mirrorActive'] = isset($data['mirrorActive']) ? $data['mirrorActive'] : null;
         $this->container['recurring'] = isset($data['recurring']) ? $data['recurring'] : null;
+        $this->container['recipients'] = isset($data['recipients']) ? $data['recipients'] : null;
+        $this->container['statistics'] = isset($data['statistics']) ? $data['statistics'] : null;
     }
 
     /**
@@ -352,6 +364,12 @@ class GetEmailCampaign implements ArrayAccess
         if ($this->container['modifiedAt'] === null) {
             $invalid_properties[] = "'modifiedAt' can't be null";
         }
+        if ($this->container['recipients'] === null) {
+            $invalid_properties[] = "'recipients' can't be null";
+        }
+        if ($this->container['statistics'] === null) {
+            $invalid_properties[] = "'statistics' can't be null";
+        }
         return $invalid_properties;
     }
 
@@ -412,6 +430,12 @@ class GetEmailCampaign implements ArrayAccess
             return false;
         }
         if ($this->container['modifiedAt'] === null) {
+            return false;
+        }
+        if ($this->container['recipients'] === null) {
+            return false;
+        }
+        if ($this->container['statistics'] === null) {
             return false;
         }
         return true;
@@ -852,6 +876,48 @@ class GetEmailCampaign implements ArrayAccess
     public function setRecurring($recurring)
     {
         $this->container['recurring'] = $recurring;
+
+        return $this;
+    }
+
+    /**
+     * Gets recipients
+     * @return object
+     */
+    public function getRecipients()
+    {
+        return $this->container['recipients'];
+    }
+
+    /**
+     * Sets recipients
+     * @param object $recipients
+     * @return $this
+     */
+    public function setRecipients($recipients)
+    {
+        $this->container['recipients'] = $recipients;
+
+        return $this;
+    }
+
+    /**
+     * Gets statistics
+     * @return object
+     */
+    public function getStatistics()
+    {
+        return $this->container['statistics'];
+    }
+
+    /**
+     * Sets statistics
+     * @param object $statistics
+     * @return $this
+     */
+    public function setStatistics($statistics)
+    {
+        $this->container['statistics'] = $statistics;
 
         return $this;
     }

--- a/lib/Model/GetSmsCampaign.php
+++ b/lib/Model/GetSmsCampaign.php
@@ -62,7 +62,9 @@ class GetSmsCampaign implements ArrayAccess
         'testSent' => 'bool',
         'sender' => 'string',
         'createdAt' => '\DateTime',
-        'modifiedAt' => '\DateTime'
+        'modifiedAt' => '\DateTime',
+        'recipients' => 'object',
+        'statistics' => 'object'
     ];
 
     /**
@@ -78,7 +80,9 @@ class GetSmsCampaign implements ArrayAccess
         'testSent' => null,
         'sender' => null,
         'createdAt' => 'date-time',
-        'modifiedAt' => 'date-time'
+        'modifiedAt' => 'date-time',
+        'recipients' => null,
+        'statistics' => null
     ];
 
     public static function swaggerTypes()
@@ -104,7 +108,9 @@ class GetSmsCampaign implements ArrayAccess
         'testSent' => 'testSent',
         'sender' => 'sender',
         'createdAt' => 'createdAt',
-        'modifiedAt' => 'modifiedAt'
+        'modifiedAt' => 'modifiedAt',
+        'recipients' => 'recipients',
+        'statistics' => 'statistics'
     ];
 
 
@@ -121,7 +127,9 @@ class GetSmsCampaign implements ArrayAccess
         'testSent' => 'setTestSent',
         'sender' => 'setSender',
         'createdAt' => 'setCreatedAt',
-        'modifiedAt' => 'setModifiedAt'
+        'modifiedAt' => 'setModifiedAt',
+        'recipients' => 'setRecipients',
+        'statistics' => 'setStatistics'
     ];
 
 
@@ -138,7 +146,9 @@ class GetSmsCampaign implements ArrayAccess
         'testSent' => 'getTestSent',
         'sender' => 'getSender',
         'createdAt' => 'getCreatedAt',
-        'modifiedAt' => 'getModifiedAt'
+        'modifiedAt' => 'getModifiedAt',
+        'recipients' => 'getRecipients',
+        'statistics' => 'getStatistics'
     ];
 
     public static function attributeMap()
@@ -203,6 +213,8 @@ class GetSmsCampaign implements ArrayAccess
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;
         $this->container['modifiedAt'] = isset($data['modifiedAt']) ? $data['modifiedAt'] : null;
+        $this->container['recipients'] = isset($data['recipients']) ? $data['recipients'] : null;
+        $this->container['statistics'] = isset($data['statistics']) ? $data['statistics'] : null;
     }
 
     /**
@@ -249,6 +261,12 @@ class GetSmsCampaign implements ArrayAccess
         if ($this->container['modifiedAt'] === null) {
             $invalid_properties[] = "'modifiedAt' can't be null";
         }
+        if ($this->container['recipients'] === null) {
+            $invalid_properties[] = "'recipients' can't be null";
+        }
+        if ($this->container['statistics'] === null) {
+            $invalid_properties[] = "'statistics' can't be null";
+        }
         return $invalid_properties;
     }
 
@@ -290,6 +308,12 @@ class GetSmsCampaign implements ArrayAccess
             return false;
         }
         if ($this->container['modifiedAt'] === null) {
+            return false;
+        }
+        if ($this->container['recipients'] === null) {
+            return false;
+        }
+        if ($this->container['statistics'] === null) {
             return false;
         }
         return true;
@@ -490,6 +514,48 @@ class GetSmsCampaign implements ArrayAccess
     public function setModifiedAt($modifiedAt)
     {
         $this->container['modifiedAt'] = $modifiedAt;
+
+        return $this;
+    }
+
+    /**
+     * Gets recipients
+     * @return object
+     */
+    public function getRecipients()
+    {
+        return $this->container['recipients'];
+    }
+
+    /**
+     * Sets recipients
+     * @param object $recipients
+     * @return $this
+     */
+    public function setRecipients($recipients)
+    {
+        $this->container['recipients'] = $recipients;
+
+        return $this;
+    }
+
+    /**
+     * Gets statistics
+     * @return object
+     */
+    public function getStatistics()
+    {
+        return $this->container['statistics'];
+    }
+
+    /**
+     * Sets statistics
+     * @param object $statistics
+     * @return $this
+     */
+    public function setStatistics($statistics)
+    {
+        $this->container['statistics'] = $statistics;
 
         return $this;
     }

--- a/lib/Model/ManageIp.php
+++ b/lib/Model/ManageIp.php
@@ -54,7 +54,7 @@ class ManageIp implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'ipId' => 'int'
+        'ip' => 'string'
     ];
 
     /**
@@ -62,7 +62,7 @@ class ManageIp implements ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'ipId' => 'int64'
+        'ip' => null
     ];
 
     public static function swaggerTypes()
@@ -80,7 +80,7 @@ class ManageIp implements ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'ipId' => 'ipId'
+        'ip' => 'ip'
     ];
 
 
@@ -89,7 +89,7 @@ class ManageIp implements ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'ipId' => 'setIpId'
+        'ip' => 'setIp'
     ];
 
 
@@ -98,7 +98,7 @@ class ManageIp implements ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'ipId' => 'getIpId'
+        'ip' => 'getIp'
     ];
 
     public static function attributeMap()
@@ -132,7 +132,7 @@ class ManageIp implements ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['ipId'] = isset($data['ipId']) ? $data['ipId'] : null;
+        $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
     }
 
     /**
@@ -161,22 +161,22 @@ class ManageIp implements ArrayAccess
 
 
     /**
-     * Gets ipId
-     * @return int
+     * Gets ip
+     * @return string
      */
-    public function getIpId()
+    public function getIp()
     {
-        return $this->container['ipId'];
+        return $this->container['ip'];
     }
 
     /**
-     * Sets ipId
-     * @param int $ipId ID of the IP
+     * Sets ip
+     * @param string $ip Dedicated ID
      * @return $this
      */
-    public function setIpId($ipId)
+    public function setIp($ip)
     {
-        $this->container['ipId'] = $ipId;
+        $this->container['ip'] = $ip;
 
         return $this;
     }

--- a/lib/Model/RemoveCredits.php
+++ b/lib/Model/RemoveCredits.php
@@ -177,7 +177,7 @@ class RemoveCredits implements ArrayAccess
 
     /**
      * Sets sms
-     * @param int $sms SMS credits to be removed from the child account
+     * @param int $sms Required if email credits are empty. SMS credits to be removed from the child account
      * @return $this
      */
     public function setSms($sms)
@@ -198,7 +198,7 @@ class RemoveCredits implements ArrayAccess
 
     /**
      * Sets email
-     * @param int $email Email credits to be removed from the child account
+     * @param int $email Required if sms credits are empty. Email credits to be removed from the child account
      * @return $this
      */
     public function setEmail($email)

--- a/lib/Model/SendSmtpEmail.php
+++ b/lib/Model/SendSmtpEmail.php
@@ -63,7 +63,9 @@ class SendSmtpEmail implements ArrayAccess
         'subject' => 'string',
         'replyTo' => '\SendinBlue\Client\Model\SendSmtpEmailReplyTo',
         'attachment' => '\SendinBlue\Client\Model\SendSmtpEmailAttachment[]',
-        'headers' => 'map[string,string]'
+        'headers' => 'map[string,string]',
+        'templateId' => 'int',
+        'params' => 'map[string,string]'
     ];
 
     /**
@@ -80,7 +82,9 @@ class SendSmtpEmail implements ArrayAccess
         'subject' => null,
         'replyTo' => null,
         'attachment' => null,
-        'headers' => null
+        'headers' => null,
+        'templateId' => 'int64',
+        'params' => null
     ];
 
     public static function swaggerTypes()
@@ -107,7 +111,9 @@ class SendSmtpEmail implements ArrayAccess
         'subject' => 'subject',
         'replyTo' => 'replyTo',
         'attachment' => 'attachment',
-        'headers' => 'headers'
+        'headers' => 'headers',
+        'templateId' => 'templateId',
+        'params' => 'params'
     ];
 
 
@@ -125,7 +131,9 @@ class SendSmtpEmail implements ArrayAccess
         'subject' => 'setSubject',
         'replyTo' => 'setReplyTo',
         'attachment' => 'setAttachment',
-        'headers' => 'setHeaders'
+        'headers' => 'setHeaders',
+        'templateId' => 'setTemplateId',
+        'params' => 'setParams'
     ];
 
 
@@ -143,7 +151,9 @@ class SendSmtpEmail implements ArrayAccess
         'subject' => 'getSubject',
         'replyTo' => 'getReplyTo',
         'attachment' => 'getAttachment',
-        'headers' => 'getHeaders'
+        'headers' => 'getHeaders',
+        'templateId' => 'getTemplateId',
+        'params' => 'getParams'
     ];
 
     public static function attributeMap()
@@ -187,6 +197,8 @@ class SendSmtpEmail implements ArrayAccess
         $this->container['replyTo'] = isset($data['replyTo']) ? $data['replyTo'] : null;
         $this->container['attachment'] = isset($data['attachment']) ? $data['attachment'] : null;
         $this->container['headers'] = isset($data['headers']) ? $data['headers'] : null;
+        $this->container['templateId'] = isset($data['templateId']) ? $data['templateId'] : null;
+        $this->container['params'] = isset($data['params']) ? $data['params'] : null;
     }
 
     /**
@@ -201,12 +213,6 @@ class SendSmtpEmail implements ArrayAccess
         if ($this->container['to'] === null) {
             $invalid_properties[] = "'to' can't be null";
         }
-        if ($this->container['htmlContent'] === null) {
-            $invalid_properties[] = "'htmlContent' can't be null";
-        }
-        if ($this->container['subject'] === null) {
-            $invalid_properties[] = "'subject' can't be null";
-        }
         return $invalid_properties;
     }
 
@@ -220,12 +226,6 @@ class SendSmtpEmail implements ArrayAccess
     {
 
         if ($this->container['to'] === null) {
-            return false;
-        }
-        if ($this->container['htmlContent'] === null) {
-            return false;
-        }
-        if ($this->container['subject'] === null) {
             return false;
         }
         return true;
@@ -327,7 +327,7 @@ class SendSmtpEmail implements ArrayAccess
 
     /**
      * Sets htmlContent
-     * @param string $htmlContent HTML body of the message
+     * @param string $htmlContent HTML body of the message ( Mandatory if 'templateId' is not passed, ignored if 'templateId' is passed )
      * @return $this
      */
     public function setHtmlContent($htmlContent)
@@ -348,7 +348,7 @@ class SendSmtpEmail implements ArrayAccess
 
     /**
      * Sets textContent
-     * @param string $textContent Plain Text body of the message
+     * @param string $textContent Plain Text body of the message ( Ignored if 'templateId' is passed )
      * @return $this
      */
     public function setTextContent($textContent)
@@ -369,7 +369,7 @@ class SendSmtpEmail implements ArrayAccess
 
     /**
      * Sets subject
-     * @param string $subject Subject of the message
+     * @param string $subject Subject of the message. Mandatory if 'templateId' is not passed
      * @return $this
      */
     public function setSubject($subject)
@@ -411,7 +411,7 @@ class SendSmtpEmail implements ArrayAccess
 
     /**
      * Sets attachment
-     * @param \SendinBlue\Client\Model\SendSmtpEmailAttachment[] $attachment Pass the absolute URL (no local file) or the base64 content of the attachment. Name can be used in both cases to define the attachment name. It is mandatory in case of content. Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps
+     * @param \SendinBlue\Client\Model\SendSmtpEmailAttachment[] $attachment Pass the absolute URL (no local file) or the base64 content of the attachment. Name can be used in both cases to define the attachment name. It is mandatory in case of content. Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps ( Ignored if 'templateId' is passed )
      * @return $this
      */
     public function setAttachment($attachment)
@@ -438,6 +438,48 @@ class SendSmtpEmail implements ArrayAccess
     public function setHeaders($headers)
     {
         $this->container['headers'] = $headers;
+
+        return $this;
+    }
+
+    /**
+     * Gets templateId
+     * @return int
+     */
+    public function getTemplateId()
+    {
+        return $this->container['templateId'];
+    }
+
+    /**
+     * Sets templateId
+     * @param int $templateId Id of the template
+     * @return $this
+     */
+    public function setTemplateId($templateId)
+    {
+        $this->container['templateId'] = $templateId;
+
+        return $this;
+    }
+
+    /**
+     * Gets params
+     * @return map[string,string]
+     */
+    public function getParams()
+    {
+        return $this->container['params'];
+    }
+
+    /**
+     * Sets params
+     * @param map[string,string] $params
+     * @return $this
+     */
+    public function setParams($params)
+    {
+        $this->container['params'] = $params;
 
         return $this;
     }

--- a/lib/Model/SendSmtpEmailSender.php
+++ b/lib/Model/SendSmtpEmailSender.php
@@ -35,6 +35,7 @@ use \ArrayAccess;
  * SendSmtpEmailSender Class Doc Comment
  *
  * @category    Class
+ * @description Sender from which emails are sent. Mandatory if &#39;templateId&#39; is not passed
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen

--- a/lib/Model/UpdateChild.php
+++ b/lib/Model/UpdateChild.php
@@ -58,8 +58,7 @@ class UpdateChild implements ArrayAccess
         'firstName' => 'string',
         'lastName' => 'string',
         'companyName' => 'string',
-        'password' => 'string',
-        'ips' => 'int[]'
+        'password' => 'string'
     ];
 
     /**
@@ -71,8 +70,7 @@ class UpdateChild implements ArrayAccess
         'firstName' => null,
         'lastName' => null,
         'companyName' => null,
-        'password' => 'password',
-        'ips' => 'int64'
+        'password' => 'password'
     ];
 
     public static function swaggerTypes()
@@ -94,8 +92,7 @@ class UpdateChild implements ArrayAccess
         'firstName' => 'firstName',
         'lastName' => 'lastName',
         'companyName' => 'companyName',
-        'password' => 'password',
-        'ips' => 'ips'
+        'password' => 'password'
     ];
 
 
@@ -108,8 +105,7 @@ class UpdateChild implements ArrayAccess
         'firstName' => 'setFirstName',
         'lastName' => 'setLastName',
         'companyName' => 'setCompanyName',
-        'password' => 'setPassword',
-        'ips' => 'setIps'
+        'password' => 'setPassword'
     ];
 
 
@@ -122,8 +118,7 @@ class UpdateChild implements ArrayAccess
         'firstName' => 'getFirstName',
         'lastName' => 'getLastName',
         'companyName' => 'getCompanyName',
-        'password' => 'getPassword',
-        'ips' => 'getIps'
+        'password' => 'getPassword'
     ];
 
     public static function attributeMap()
@@ -162,7 +157,6 @@ class UpdateChild implements ArrayAccess
         $this->container['lastName'] = isset($data['lastName']) ? $data['lastName'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;
         $this->container['password'] = isset($data['password']) ? $data['password'] : null;
-        $this->container['ips'] = isset($data['ips']) ? $data['ips'] : null;
     }
 
     /**
@@ -291,27 +285,6 @@ class UpdateChild implements ArrayAccess
     public function setPassword($password)
     {
         $this->container['password'] = $password;
-
-        return $this;
-    }
-
-    /**
-     * Gets ips
-     * @return int[]
-     */
-    public function getIps()
-    {
-        return $this->container['ips'];
-    }
-
-    /**
-     * Sets ips
-     * @param int[] $ips
-     * @return $this
-     */
-    public function setIps($ips)
-    {
-        $this->container['ips'] = $ips;
 
         return $this;
     }

--- a/test/Api/ResellerApiTest.php
+++ b/test/Api/ResellerApiTest.php
@@ -105,7 +105,7 @@ class ResellerApiTest extends \PHPUnit_Framework_TestCase
     /**
      * Test case for deleteResellerChild
      *
-     * Deletes a single reseller child based on the childId supplied.
+     * Deletes a single reseller child based on the childAuthKey supplied.
      *
      */
     public function testDeleteResellerChild()
@@ -155,7 +155,7 @@ class ResellerApiTest extends \PHPUnit_Framework_TestCase
     /**
      * Test case for updateResellerChild
      *
-     * Updates infos of reseller's child based on the childId supplied.
+     * Updates infos of reseller's child based on the childAuthKey supplied.
      *
      */
     public function testUpdateResellerChild()

--- a/test/Model/CreateResellerTest.php
+++ b/test/Model/CreateResellerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * UpdateChildTest
+ * CreateResellerTest
  *
  * PHP version 5
  *
@@ -30,16 +30,16 @@
 namespace SendinBlue\Client;
 
 /**
- * UpdateChildTest Class Doc Comment
+ * CreateResellerTest Class Doc Comment
  *
  * @category    Class */
-// * @description UpdateChild
+// * @description CreateReseller
 /**
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class UpdateChildTest extends \PHPUnit_Framework_TestCase
+class CreateResellerTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -71,44 +71,16 @@ class UpdateChildTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "UpdateChild"
+     * Test "CreateReseller"
      */
-    public function testUpdateChild()
+    public function testCreateReseller()
     {
     }
 
     /**
-     * Test attribute "email"
+     * Test attribute "authKey"
      */
-    public function testPropertyEmail()
-    {
-    }
-
-    /**
-     * Test attribute "firstName"
-     */
-    public function testPropertyFirstName()
-    {
-    }
-
-    /**
-     * Test attribute "lastName"
-     */
-    public function testPropertyLastName()
-    {
-    }
-
-    /**
-     * Test attribute "companyName"
-     */
-    public function testPropertyCompanyName()
-    {
-    }
-
-    /**
-     * Test attribute "password"
-     */
-    public function testPropertyPassword()
+    public function testPropertyAuthKey()
     {
     }
 }

--- a/test/Model/GetChildInfoApiKeysTest.php
+++ b/test/Model/GetChildInfoApiKeysTest.php
@@ -33,7 +33,7 @@ namespace SendinBlue\Client;
  * GetChildInfoApiKeysTest Class Doc Comment
  *
  * @category    Class */
-// * @description GetChildInfoApiKeys
+// * @description API Keys associated to child account
 /**
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
@@ -78,23 +78,16 @@ class GetChildInfoApiKeysTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test attribute "name"
+     * Test attribute "v2"
      */
-    public function testPropertyName()
+    public function testPropertyV2()
     {
     }
 
     /**
-     * Test attribute "key"
+     * Test attribute "v3"
      */
-    public function testPropertyKey()
-    {
-    }
-
-    /**
-     * Test attribute "secret"
-     */
-    public function testPropertySecret()
+    public function testPropertyV3()
     {
     }
 }

--- a/test/Model/GetChildInfoApiKeysV2Test.php
+++ b/test/Model/GetChildInfoApiKeysV2Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * UpdateChildTest
+ * GetChildInfoApiKeysV2Test
  *
  * PHP version 5
  *
@@ -30,16 +30,16 @@
 namespace SendinBlue\Client;
 
 /**
- * UpdateChildTest Class Doc Comment
+ * GetChildInfoApiKeysV2Test Class Doc Comment
  *
  * @category    Class */
-// * @description UpdateChild
+// * @description GetChildInfoApiKeysV2
 /**
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class UpdateChildTest extends \PHPUnit_Framework_TestCase
+class GetChildInfoApiKeysV2Test extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -71,44 +71,23 @@ class UpdateChildTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "UpdateChild"
+     * Test "GetChildInfoApiKeysV2"
      */
-    public function testUpdateChild()
+    public function testGetChildInfoApiKeysV2()
     {
     }
 
     /**
-     * Test attribute "email"
+     * Test attribute "name"
      */
-    public function testPropertyEmail()
+    public function testPropertyName()
     {
     }
 
     /**
-     * Test attribute "firstName"
+     * Test attribute "key"
      */
-    public function testPropertyFirstName()
-    {
-    }
-
-    /**
-     * Test attribute "lastName"
-     */
-    public function testPropertyLastName()
-    {
-    }
-
-    /**
-     * Test attribute "companyName"
-     */
-    public function testPropertyCompanyName()
-    {
-    }
-
-    /**
-     * Test attribute "password"
-     */
-    public function testPropertyPassword()
+    public function testPropertyKey()
     {
     }
 }

--- a/test/Model/GetChildInfoApiKeysV3Test.php
+++ b/test/Model/GetChildInfoApiKeysV3Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * GetChildInfoIpsTest
+ * GetChildInfoApiKeysV3Test
  *
  * PHP version 5
  *
@@ -30,16 +30,16 @@
 namespace SendinBlue\Client;
 
 /**
- * GetChildInfoIpsTest Class Doc Comment
+ * GetChildInfoApiKeysV3Test Class Doc Comment
  *
  * @category    Class */
-// * @description GetChildInfoIps
+// * @description GetChildInfoApiKeysV3
 /**
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class GetChildInfoIpsTest extends \PHPUnit_Framework_TestCase
+class GetChildInfoApiKeysV3Test extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -71,23 +71,23 @@ class GetChildInfoIpsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "GetChildInfoIps"
+     * Test "GetChildInfoApiKeysV3"
      */
-    public function testGetChildInfoIps()
+    public function testGetChildInfoApiKeysV3()
     {
     }
 
     /**
-     * Test attribute "id"
+     * Test attribute "name"
      */
-    public function testPropertyId()
+    public function testPropertyName()
     {
     }
 
     /**
-     * Test attribute "ip"
+     * Test attribute "key"
      */
-    public function testPropertyIp()
+    public function testPropertyKey()
     {
     }
 }

--- a/test/Model/GetEmailCampaignTest.php
+++ b/test/Model/GetEmailCampaignTest.php
@@ -216,4 +216,18 @@ class GetEmailCampaignTest extends \PHPUnit_Framework_TestCase
     public function testPropertyRecurring()
     {
     }
+
+    /**
+     * Test attribute "recipients"
+     */
+    public function testPropertyRecipients()
+    {
+    }
+
+    /**
+     * Test attribute "statistics"
+     */
+    public function testPropertyStatistics()
+    {
+    }
 }

--- a/test/Model/GetSmsCampaignTest.php
+++ b/test/Model/GetSmsCampaignTest.php
@@ -139,4 +139,18 @@ class GetSmsCampaignTest extends \PHPUnit_Framework_TestCase
     public function testPropertyModifiedAt()
     {
     }
+
+    /**
+     * Test attribute "recipients"
+     */
+    public function testPropertyRecipients()
+    {
+    }
+
+    /**
+     * Test attribute "statistics"
+     */
+    public function testPropertyStatistics()
+    {
+    }
 }

--- a/test/Model/ManageIpTest.php
+++ b/test/Model/ManageIpTest.php
@@ -78,9 +78,9 @@ class ManageIpTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test attribute "ipId"
+     * Test attribute "ip"
      */
-    public function testPropertyIpId()
+    public function testPropertyIp()
     {
     }
 }

--- a/test/Model/SendSmtpEmailSenderTest.php
+++ b/test/Model/SendSmtpEmailSenderTest.php
@@ -33,7 +33,7 @@ namespace SendinBlue\Client;
  * SendSmtpEmailSenderTest Class Doc Comment
  *
  * @category    Class */
-// * @description SendSmtpEmailSender
+// * @description Sender from which emails are sent. Mandatory if &#39;templateId&#39; is not passed
 /**
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team

--- a/test/Model/SendSmtpEmailTest.php
+++ b/test/Model/SendSmtpEmailTest.php
@@ -146,4 +146,18 @@ class SendSmtpEmailTest extends \PHPUnit_Framework_TestCase
     public function testPropertyHeaders()
     {
     }
+
+    /**
+     * Test attribute "templateId"
+     */
+    public function testPropertyTemplateId()
+    {
+    }
+
+    /**
+     * Test attribute "params"
+     */
+    public function testPropertyParams()
+    {
+    }
 }


### PR DESCRIPTION
- Fix `type: object` field in `getSmsCampaign` & `getEmailCampaign` definition for good response in get email/sms campaigns 
- Added `templateId` & `params` as new input in `sendSmtpEmail` definition
- Renaming of some method names