### PR TITLE
Delete single contact method added + get account response fix for reseller

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Class | Method | HTTP request | Description
 *ContactsApi* | [**createFolder**](docs/Api/ContactsApi.md#createfolder) | **POST** /contacts/folders | Create a folder
 *ContactsApi* | [**createList**](docs/Api/ContactsApi.md#createlist) | **POST** /contacts/lists | Create a list
 *ContactsApi* | [**deleteAttribute**](docs/Api/ContactsApi.md#deleteattribute) | **DELETE** /contacts/attributes/{attributeCategory}/{attributeName} | Deletes an attribute
+*ContactsApi* | [**deleteContact**](docs/Api/ContactsApi.md#deletecontact) | **DELETE** /contacts/{email} | Deletes a contact
 *ContactsApi* | [**deleteFolder**](docs/Api/ContactsApi.md#deletefolder) | **DELETE** /contacts/folders/{folderId} | Delete a folder (and all its lists)
 *ContactsApi* | [**deleteList**](docs/Api/ContactsApi.md#deletelist) | **DELETE** /contacts/lists/{listId} | Delete a list
 *ContactsApi* | [**getAttributes**](docs/Api/ContactsApi.md#getattributes) | **GET** /contacts/attributes | Lists all attributes

--- a/docs/Api/ContactsApi.md
+++ b/docs/Api/ContactsApi.md
@@ -10,6 +10,7 @@ Method | HTTP request | Description
 [**createFolder**](ContactsApi.md#createFolder) | **POST** /contacts/folders | Create a folder
 [**createList**](ContactsApi.md#createList) | **POST** /contacts/lists | Create a list
 [**deleteAttribute**](ContactsApi.md#deleteAttribute) | **DELETE** /contacts/attributes/{attributeCategory}/{attributeName} | Deletes an attribute
+[**deleteContact**](ContactsApi.md#deleteContact) | **DELETE** /contacts/{email} | Deletes a contact
 [**deleteFolder**](ContactsApi.md#deleteFolder) | **DELETE** /contacts/folders/{folderId} | Delete a folder (and all its lists)
 [**deleteList**](ContactsApi.md#deleteList) | **DELETE** /contacts/lists/{listId} | Delete a list
 [**getAttributes**](ContactsApi.md#getAttributes) | **GET** /contacts/attributes | Lists all attributes
@@ -309,6 +310,53 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **attributeCategory** | **string**| Category of the attribute |
  **attributeName** | **string**| Name of the existing attribute |
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[api-key](../../README.md#api-key)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+# **deleteContact**
+> deleteContact($email)
+
+Deletes a contact
+
+### Example
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: api-key
+SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
+
+$api_instance = new SendinBlue\Client\Api\ContactsApi();
+$email = "email_example"; // string | Email (urlencoded) of the contact
+
+try {
+    $api_instance->deleteContact($email);
+} catch (Exception $e) {
+    echo 'Exception when calling ContactsApi->deleteContact: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **email** | **string**| Email (urlencoded) of the contact |
 
 ### Return type
 

--- a/docs/Model/GetAccountPlan.md
+++ b/docs/Model/GetAccountPlan.md
@@ -4,10 +4,11 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **type** | **string** | Displays the plan type of the user | 
-**creditsType** | **string** | This is the type of the credit, \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; are two possible types of credit of a user. \&quot;User Limit\&quot; implies the total number of subscribers you can add to your account, and \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account. | 
-**credits** | **float** | Remaining credits of the user. This can either be \&quot;User Limit\&quot; or \&quot;Send Limit\&quot; depending on the plan. | 
+**creditsType** | **string** | This is the type of the credit, \&quot;Send Limit\&quot; is one of the possible types of credit of a user. \&quot;Send Limit\&quot; implies the total number of emails you can send to the subscribers in your account. | 
+**credits** | **float** | Remaining credits of the user
 **startDate** | **\DateTime** | Date of the period from which the plan will start (only available for \&quot;subscription\&quot;, \&quot;unlimited\&quot; and \&quot;reseller\&quot; plan type) | [optional] 
 **endDate** | **\DateTime** | Date of the period from which the plan will end (only available for \&quot;subscription\&quot;, \&quot;unlimited\&quot; and \&quot;reseller\&quot; plan type) | [optional] 
+**userLimit** | **int** | Only in case of reseller account. It implies the total number of child accounts you can add to your account. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/SendSmtpEmail.md
+++ b/docs/Model/SendSmtpEmail.md
@@ -7,12 +7,14 @@ Name | Type | Description | Notes
 **to** | [**\SendinBlue\Client\Model\SendSmtpEmailTo[]**](SendSmtpEmailTo.md) | Email addresses and names of the recipients | 
 **bcc** | [**\SendinBlue\Client\Model\SendSmtpEmailBcc[]**](SendSmtpEmailBcc.md) | Email addresses and names of the recipients in bcc | [optional] 
 **cc** | [**\SendinBlue\Client\Model\SendSmtpEmailCc[]**](SendSmtpEmailCc.md) | Email addresses and names of the recipients in cc | [optional] 
-**htmlContent** | **string** | HTML body of the message | 
-**textContent** | **string** | Plain Text body of the message | [optional] 
-**subject** | **string** | Subject of the message | 
+**htmlContent** | **string** | HTML body of the message ( Mandatory if &#39;templateId&#39; is not passed, ignored if &#39;templateId&#39; is passed ) | [optional] 
+**textContent** | **string** | Plain Text body of the message ( Ignored if &#39;templateId&#39; is passed ) | [optional] 
+**subject** | **string** | Subject of the message. Mandatory if &#39;templateId&#39; is not passed | [optional] 
 **replyTo** | [**\SendinBlue\Client\Model\SendSmtpEmailReplyTo**](SendSmtpEmailReplyTo.md) |  | [optional] 
-**attachment** | [**\SendinBlue\Client\Model\SendSmtpEmailAttachment[]**](SendSmtpEmailAttachment.md) | Pass the absolute URL (no local file) or the base64 content of the attachment. Name can be used in both cases to define the attachment name. It is mandatory in case of content. Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps | [optional] 
+**attachment** | [**\SendinBlue\Client\Model\SendSmtpEmailAttachment[]**](SendSmtpEmailAttachment.md) | Pass the absolute URL (no local file) or the base64 content of the attachment. Name can be used in both cases to define the attachment name. It is mandatory in case of content. Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps ( Ignored if &#39;templateId&#39; is passed ) | [optional] 
 **headers** | **map[string,string]** |  | [optional] 
+**templateId** | **int** | Id of the template | [optional] 
+**params** | **map[string,string]** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/lib/Api/ContactsApi.php
+++ b/lib/Api/ContactsApi.php
@@ -675,6 +675,97 @@ class ContactsApi
     }
 
     /**
+     * Operation deleteContact
+     *
+     * Deletes a contact
+     *
+     * @param string $email Email (urlencoded) of the contact (required)
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @return void
+     */
+    public function deleteContact($email)
+    {
+        list($response) = $this->deleteContactWithHttpInfo($email);
+        return $response;
+    }
+
+    /**
+     * Operation deleteContactWithHttpInfo
+     *
+     * Deletes a contact
+     *
+     * @param string $email Email (urlencoded) of the contact (required)
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function deleteContactWithHttpInfo($email)
+    {
+        // verify the required parameter 'email' is set
+        if ($email === null) {
+            throw new \InvalidArgumentException('Missing the required parameter $email when calling deleteContact');
+        }
+        // parse inputs
+        $resourcePath = "/contacts/{email}";
+        $httpBody = '';
+        $queryParams = [];
+        $headerParams = [];
+        $formParams = [];
+        $_header_accept = $this->apiClient->selectHeaderAccept(['application/json']);
+        if (!is_null($_header_accept)) {
+            $headerParams['Accept'] = $_header_accept;
+        }
+        $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
+
+        // path params
+        if ($email !== null) {
+            $resourcePath = str_replace(
+                "{" . "email" . "}",
+                $this->apiClient->getSerializer()->toPathValue($email),
+                $resourcePath
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
+        } elseif (count($formParams) > 0) {
+            $httpBody = $formParams; // for HTTP post (form)
+        }
+        // this endpoint requires API key authentication
+        $apiKey = $this->apiClient->getApiKeyWithPrefix('api-key');
+        if (strlen($apiKey) !== 0) {
+            $headerParams['api-key'] = $apiKey;
+        }
+        // make the API Call
+        try {
+            list($response, $statusCode, $httpHeader) = $this->apiClient->callApi(
+                $resourcePath,
+                'DELETE',
+                $queryParams,
+                $httpBody,
+                $headerParams,
+                null,
+                '/contacts/{email}'
+            );
+
+            return [null, $statusCode, $httpHeader];
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 400:
+                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\SendinBlue\Client\Model\ErrorModel', $e->getResponseHeaders());
+                    $e->setResponseObject($data);
+                    break;
+                case 404:
+                    $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\SendinBlue\Client\Model\ErrorModel', $e->getResponseHeaders());
+                    $e->setResponseObject($data);
+                    break;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
      * Operation deleteFolder
      *
      * Delete a folder (and all its lists)

--- a/lib/Model/GetAccountPlan.php
+++ b/lib/Model/GetAccountPlan.php
@@ -58,7 +58,8 @@ class GetAccountPlan implements ArrayAccess
         'creditsType' => 'string',
         'credits' => 'float',
         'startDate' => '\DateTime',
-        'endDate' => '\DateTime'
+        'endDate' => '\DateTime',
+        'userLimit' => 'int'
     ];
 
     /**
@@ -70,7 +71,8 @@ class GetAccountPlan implements ArrayAccess
         'creditsType' => null,
         'credits' => 'float',
         'startDate' => 'date',
-        'endDate' => 'date'
+        'endDate' => 'date',
+        'userLimit' => null
     ];
 
     public static function swaggerTypes()
@@ -92,7 +94,8 @@ class GetAccountPlan implements ArrayAccess
         'creditsType' => 'creditsType',
         'credits' => 'credits',
         'startDate' => 'startDate',
-        'endDate' => 'endDate'
+        'endDate' => 'endDate',
+        'userLimit' => 'userLimit'
     ];
 
 
@@ -105,7 +108,8 @@ class GetAccountPlan implements ArrayAccess
         'creditsType' => 'setCreditsType',
         'credits' => 'setCredits',
         'startDate' => 'setStartDate',
-        'endDate' => 'setEndDate'
+        'endDate' => 'setEndDate',
+        'userLimit' => 'setUserLimit'
     ];
 
 
@@ -118,7 +122,8 @@ class GetAccountPlan implements ArrayAccess
         'creditsType' => 'getCreditsType',
         'credits' => 'getCredits',
         'startDate' => 'getStartDate',
-        'endDate' => 'getEndDate'
+        'endDate' => 'getEndDate',
+        'userLimit' => 'getUserLimit'
     ];
 
     public static function attributeMap()
@@ -142,7 +147,6 @@ class GetAccountPlan implements ArrayAccess
     const TYPE_SUBSCRIPTION = 'subscription';
     const TYPE_SMS = 'sms';
     const TYPE_RESELLER = 'reseller';
-    const CREDITS_TYPE_USER_LIMIT = 'userLimit';
     const CREDITS_TYPE_SEND_LIMIT = 'sendLimit';
     
 
@@ -170,7 +174,6 @@ class GetAccountPlan implements ArrayAccess
     public function getCreditsTypeAllowableValues()
     {
         return [
-            self::CREDITS_TYPE_USER_LIMIT,
             self::CREDITS_TYPE_SEND_LIMIT,
         ];
     }
@@ -193,6 +196,7 @@ class GetAccountPlan implements ArrayAccess
         $this->container['credits'] = isset($data['credits']) ? $data['credits'] : null;
         $this->container['startDate'] = isset($data['startDate']) ? $data['startDate'] : null;
         $this->container['endDate'] = isset($data['endDate']) ? $data['endDate'] : null;
+        $this->container['userLimit'] = isset($data['userLimit']) ? $data['userLimit'] : null;
     }
 
     /**
@@ -303,7 +307,7 @@ class GetAccountPlan implements ArrayAccess
 
     /**
      * Sets creditsType
-     * @param string $creditsType This is the type of the credit, \"User Limit\" or \"Send Limit\" are two possible types of credit of a user. \"User Limit\" implies the total number of subscribers you can add to your account, and \"Send Limit\" implies the total number of emails you can send to the subscribers in your account.
+     * @param string $creditsType This is the type of the credit, \"Send Limit\" is one of the possible types of credit of a user. \"Send Limit\" implies the total number of emails you can send to the subscribers in your account.
      * @return $this
      */
     public function setCreditsType($creditsType)
@@ -333,7 +337,7 @@ class GetAccountPlan implements ArrayAccess
 
     /**
      * Sets credits
-     * @param float $credits Remaining credits of the user. This can either be \"User Limit\" or \"Send Limit\" depending on the plan.
+     * @param float $credits Remaining credits of the user
      * @return $this
      */
     public function setCredits($credits)
@@ -381,6 +385,27 @@ class GetAccountPlan implements ArrayAccess
     public function setEndDate($endDate)
     {
         $this->container['endDate'] = $endDate;
+
+        return $this;
+    }
+
+    /**
+     * Gets userLimit
+     * @return int
+     */
+    public function getUserLimit()
+    {
+        return $this->container['userLimit'];
+    }
+
+    /**
+     * Sets userLimit
+     * @param int $userLimit Only in case of reseller account. It implies the total number of child accounts you can add to your account.
+     * @return $this
+     */
+    public function setUserLimit($userLimit)
+    {
+        $this->container['userLimit'] = $userLimit;
 
         return $this;
     }

--- a/test/Api/ContactsApiTest.php
+++ b/test/Api/ContactsApiTest.php
@@ -133,6 +133,16 @@ class ContactsApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test case for deleteContact
+     *
+     * Deletes a contact.
+     *
+     */
+    public function testDeleteContact()
+    {
+    }
+
+    /**
      * Test case for deleteFolder
      *
      * Delete a folder (and all its lists).

--- a/test/Model/GetAccountPlanTest.php
+++ b/test/Model/GetAccountPlanTest.php
@@ -111,4 +111,11 @@ class GetAccountPlanTest extends \PHPUnit_Framework_TestCase
     public function testPropertyEndDate()
     {
     }
+
+    /**
+     * Test attribute "userLimit"
+     */
+    public function testPropertyUserLimit()
+    {
+    }
 }


### PR DESCRIPTION
- Add new method `DELETE /contacts/{email}` to delete single contact
- `getAccount` definition response schema fix for Reseller account