### PR TITLE
The actual data is wrapped with a "result" property

### DIFF
--- a/lib/Api/SMTPApi.php
+++ b/lib/Api/SMTPApi.php
@@ -1883,6 +1883,10 @@ class SMTPApi
                 $content = $responseBody->getContents();
                 if ($returnType !== 'string') {
                     $content = json_decode($content);
+                    
+                    if ($content->result) {
+                        $content = $content->result;
+                    }                    
                 }
             }
 

--- a/lib/Api/SMTPApi.php
+++ b/lib/Api/SMTPApi.php
@@ -150,6 +150,10 @@ class SMTPApi
                 $content = $responseBody->getContents();
                 if ($returnType !== 'string') {
                     $content = json_decode($content);
+                    
+                    if ($content->result) {
+                        $content = $content->result;
+                    }
                 }
             }
 


### PR DESCRIPTION
Don't know if it is some BC break they made in the SIB API