### PR TITLE
Update RequestSMSRecipientExport.php

### DIFF
--- a/lib/Model/RequestSMSRecipientExport.php
+++ b/lib/Model/RequestSMSRecipientExport.php
@@ -40,7 +40,7 @@ use \SendinBlue\Client\ObjectSerializer;
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class RequestSmsRecipientExport implements ModelInterface, ArrayAccess
+class RequestSMSRecipientExport implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 


### PR DESCRIPTION
This notice is produced with composer 1.10.1 :

Deprecation Notice: Class SendinBlue\Client\Model\RequestSmsRecipientExport located in XXX/vendor/sendinblue/api-v3-sdk/lib\Model\RequestSMSRecipientExport.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar://C:/composer/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201