### PR TITLE
AP-841 Updated the PHP wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PHP 5.6 and later
 To install the bindings via [Composer](http://getcomposer.org/):
 
 ```
-composer require sendinblue/api-v3-sdk "6.x.x"
+composer require sendinblue/api-v3-sdk "7.x.x"
 ```
 
 Further do:
@@ -91,12 +91,12 @@ Class | Method | HTTP request | Description
 *ContactsApi* | [**createFolder**](docs/Api/ContactsApi.md#createfolder) | **POST** /contacts/folders | Create a folder
 *ContactsApi* | [**createList**](docs/Api/ContactsApi.md#createlist) | **POST** /contacts/lists | Create a list
 *ContactsApi* | [**deleteAttribute**](docs/Api/ContactsApi.md#deleteattribute) | **DELETE** /contacts/attributes/{attributeCategory}/{attributeName} | Delete an attribute
-*ContactsApi* | [**deleteContact**](docs/Api/ContactsApi.md#deletecontact) | **DELETE** /contacts/{email} | Delete a contact
+*ContactsApi* | [**deleteContact**](docs/Api/ContactsApi.md#deletecontact) | **DELETE** /contacts/{identifier} | Delete a contact
 *ContactsApi* | [**deleteFolder**](docs/Api/ContactsApi.md#deletefolder) | **DELETE** /contacts/folders/{folderId} | Delete a folder (and all its lists)
 *ContactsApi* | [**deleteList**](docs/Api/ContactsApi.md#deletelist) | **DELETE** /contacts/lists/{listId} | Delete a list
 *ContactsApi* | [**getAttributes**](docs/Api/ContactsApi.md#getattributes) | **GET** /contacts/attributes | List all attributes
-*ContactsApi* | [**getContactInfo**](docs/Api/ContactsApi.md#getcontactinfo) | **GET** /contacts/{email} | Get a contact&#39;s details
-*ContactsApi* | [**getContactStats**](docs/Api/ContactsApi.md#getcontactstats) | **GET** /contacts/{email}/campaignStats | Get email campaigns&#39; statistics for a contact
+*ContactsApi* | [**getContactInfo**](docs/Api/ContactsApi.md#getcontactinfo) | **GET** /contacts/{identifier} | Get a contact&#39;s details
+*ContactsApi* | [**getContactStats**](docs/Api/ContactsApi.md#getcontactstats) | **GET** /contacts/{identifier}/campaignStats | Get email campaigns&#39; statistics for a contact
 *ContactsApi* | [**getContacts**](docs/Api/ContactsApi.md#getcontacts) | **GET** /contacts | Get all the contacts
 *ContactsApi* | [**getContactsFromList**](docs/Api/ContactsApi.md#getcontactsfromlist) | **GET** /contacts/lists/{listId}/contacts | Get contacts in a list
 *ContactsApi* | [**getFolder**](docs/Api/ContactsApi.md#getfolder) | **GET** /contacts/folders/{folderId} | Returns a folder&#39;s details
@@ -108,7 +108,7 @@ Class | Method | HTTP request | Description
 *ContactsApi* | [**removeContactFromList**](docs/Api/ContactsApi.md#removecontactfromlist) | **POST** /contacts/lists/{listId}/contacts/remove | Delete a contact from a list
 *ContactsApi* | [**requestContactExport**](docs/Api/ContactsApi.md#requestcontactexport) | **POST** /contacts/export | Export contacts
 *ContactsApi* | [**updateAttribute**](docs/Api/ContactsApi.md#updateattribute) | **PUT** /contacts/attributes/{attributeCategory}/{attributeName} | Update contact attribute
-*ContactsApi* | [**updateContact**](docs/Api/ContactsApi.md#updatecontact) | **PUT** /contacts/{email} | Update a contact
+*ContactsApi* | [**updateContact**](docs/Api/ContactsApi.md#updatecontact) | **PUT** /contacts/{identifier} | Update a contact
 *ContactsApi* | [**updateFolder**](docs/Api/ContactsApi.md#updatefolder) | **PUT** /contacts/folders/{folderId} | Update a folder
 *ContactsApi* | [**updateList**](docs/Api/ContactsApi.md#updatelist) | **PUT** /contacts/lists/{listId} | Update a list
 *EmailCampaignsApi* | [**createEmailCampaign**](docs/Api/EmailCampaignsApi.md#createemailcampaign) | **POST** /emailCampaigns | Create an email campaign
@@ -167,29 +167,29 @@ Class | Method | HTTP request | Description
 *SMSCampaignsApi* | [**sendTestSms**](docs/Api/SMSCampaignsApi.md#sendtestsms) | **POST** /smsCampaigns/{campaignId}/sendTest | Send a test SMS campaign
 *SMSCampaignsApi* | [**updateSmsCampaign**](docs/Api/SMSCampaignsApi.md#updatesmscampaign) | **PUT** /smsCampaigns/{campaignId} | Update an SMS campaign
 *SMSCampaignsApi* | [**updateSmsCampaignStatus**](docs/Api/SMSCampaignsApi.md#updatesmscampaignstatus) | **PUT** /smsCampaigns/{campaignId}/status | Update a campaign&#39;s status
-*SMTPApi* | [**createSmtpTemplate**](docs/Api/SMTPApi.md#createsmtptemplate) | **POST** /smtp/templates | Create an email template
-*SMTPApi* | [**deleteHardbounces**](docs/Api/SMTPApi.md#deletehardbounces) | **POST** /smtp/deleteHardbounces | Delete hardbounces
-*SMTPApi* | [**deleteSmtpTemplate**](docs/Api/SMTPApi.md#deletesmtptemplate) | **DELETE** /smtp/templates/{templateId} | Delete an inactive email template
-*SMTPApi* | [**getAggregatedSmtpReport**](docs/Api/SMTPApi.md#getaggregatedsmtpreport) | **GET** /smtp/statistics/aggregatedReport | Get your transactional email activity aggregated over a period of time
-*SMTPApi* | [**getEmailEventReport**](docs/Api/SMTPApi.md#getemaileventreport) | **GET** /smtp/statistics/events | Get all your transactional email activity (unaggregated events)
-*SMTPApi* | [**getSmtpReport**](docs/Api/SMTPApi.md#getsmtpreport) | **GET** /smtp/statistics/reports | Get your transactional email activity aggregated per day
-*SMTPApi* | [**getSmtpTemplate**](docs/Api/SMTPApi.md#getsmtptemplate) | **GET** /smtp/templates/{templateId} | Returns the template information
-*SMTPApi* | [**getSmtpTemplates**](docs/Api/SMTPApi.md#getsmtptemplates) | **GET** /smtp/templates | Get the list of email templates
-*SMTPApi* | [**getTransacBlockedContacts**](docs/Api/SMTPApi.md#gettransacblockedcontacts) | **GET** /smtp/blockedContacts | Get the list of blocked or unsubscribed transactional contacts
-*SMTPApi* | [**getTransacEmailContent**](docs/Api/SMTPApi.md#gettransacemailcontent) | **GET** /smtp/emails/{uuid} | Get the personalized content of a sent transactional email
-*SMTPApi* | [**getTransacEmailsList**](docs/Api/SMTPApi.md#gettransacemailslist) | **GET** /smtp/emails | Get the list of transactional emails on the basis of allowed filters
-*SMTPApi* | [**sendTemplate**](docs/Api/SMTPApi.md#sendtemplate) | **POST** /smtp/templates/{templateId}/send | Send a template
-*SMTPApi* | [**sendTestTemplate**](docs/Api/SMTPApi.md#sendtesttemplate) | **POST** /smtp/templates/{templateId}/sendTest | Send a template to your test list
-*SMTPApi* | [**sendTransacEmail**](docs/Api/SMTPApi.md#sendtransacemail) | **POST** /smtp/email | Send a transactional email
-*SMTPApi* | [**smtpBlockedContactsEmailDelete**](docs/Api/SMTPApi.md#smtpblockedcontactsemaildelete) | **DELETE** /smtp/blockedContacts/{email} | Unblock or resubscribe a transactional contact
-*SMTPApi* | [**smtpLogMessageIdDelete**](docs/Api/SMTPApi.md#smtplogmessageiddelete) | **DELETE** /smtp/log/{messageId} | Delete an SMTP transactional log
-*SMTPApi* | [**updateSmtpTemplate**](docs/Api/SMTPApi.md#updatesmtptemplate) | **PUT** /smtp/templates/{templateId} | Update an email template
 *SendersApi* | [**createSender**](docs/Api/SendersApi.md#createsender) | **POST** /senders | Create a new sender
 *SendersApi* | [**deleteSender**](docs/Api/SendersApi.md#deletesender) | **DELETE** /senders/{senderId} | Delete a sender
 *SendersApi* | [**getIps**](docs/Api/SendersApi.md#getips) | **GET** /senders/ips | Get all the dedicated IPs for your account
 *SendersApi* | [**getIpsFromSender**](docs/Api/SendersApi.md#getipsfromsender) | **GET** /senders/{senderId}/ips | Get all the dedicated IPs for a sender
 *SendersApi* | [**getSenders**](docs/Api/SendersApi.md#getsenders) | **GET** /senders | Get the list of all your senders
 *SendersApi* | [**updateSender**](docs/Api/SendersApi.md#updatesender) | **PUT** /senders/{senderId} | Update a sender
+*TransactionalEmailsApi* | [**createSmtpTemplate**](docs/Api/TransactionalEmailsApi.md#createsmtptemplate) | **POST** /smtp/templates | Create an email template
+*TransactionalEmailsApi* | [**deleteHardbounces**](docs/Api/TransactionalEmailsApi.md#deletehardbounces) | **POST** /smtp/deleteHardbounces | Delete hardbounces
+*TransactionalEmailsApi* | [**deleteSmtpTemplate**](docs/Api/TransactionalEmailsApi.md#deletesmtptemplate) | **DELETE** /smtp/templates/{templateId} | Delete an inactive email template
+*TransactionalEmailsApi* | [**getAggregatedSmtpReport**](docs/Api/TransactionalEmailsApi.md#getaggregatedsmtpreport) | **GET** /smtp/statistics/aggregatedReport | Get your transactional email activity aggregated over a period of time
+*TransactionalEmailsApi* | [**getEmailEventReport**](docs/Api/TransactionalEmailsApi.md#getemaileventreport) | **GET** /smtp/statistics/events | Get all your transactional email activity (unaggregated events)
+*TransactionalEmailsApi* | [**getSmtpReport**](docs/Api/TransactionalEmailsApi.md#getsmtpreport) | **GET** /smtp/statistics/reports | Get your transactional email activity aggregated per day
+*TransactionalEmailsApi* | [**getSmtpTemplate**](docs/Api/TransactionalEmailsApi.md#getsmtptemplate) | **GET** /smtp/templates/{templateId} | Returns the template information
+*TransactionalEmailsApi* | [**getSmtpTemplates**](docs/Api/TransactionalEmailsApi.md#getsmtptemplates) | **GET** /smtp/templates | Get the list of email templates
+*TransactionalEmailsApi* | [**getTransacBlockedContacts**](docs/Api/TransactionalEmailsApi.md#gettransacblockedcontacts) | **GET** /smtp/blockedContacts | Get the list of blocked or unsubscribed transactional contacts
+*TransactionalEmailsApi* | [**getTransacEmailContent**](docs/Api/TransactionalEmailsApi.md#gettransacemailcontent) | **GET** /smtp/emails/{uuid} | Get the personalized content of a sent transactional email
+*TransactionalEmailsApi* | [**getTransacEmailsList**](docs/Api/TransactionalEmailsApi.md#gettransacemailslist) | **GET** /smtp/emails | Get the list of transactional emails on the basis of allowed filters
+*TransactionalEmailsApi* | [**sendTemplate**](docs/Api/TransactionalEmailsApi.md#sendtemplate) | **POST** /smtp/templates/{templateId}/send | Send a template
+*TransactionalEmailsApi* | [**sendTestTemplate**](docs/Api/TransactionalEmailsApi.md#sendtesttemplate) | **POST** /smtp/templates/{templateId}/sendTest | Send a template to your test list
+*TransactionalEmailsApi* | [**sendTransacEmail**](docs/Api/TransactionalEmailsApi.md#sendtransacemail) | **POST** /smtp/email | Send a transactional email
+*TransactionalEmailsApi* | [**smtpBlockedContactsEmailDelete**](docs/Api/TransactionalEmailsApi.md#smtpblockedcontactsemaildelete) | **DELETE** /smtp/blockedContacts/{email} | Unblock or resubscribe a transactional contact
+*TransactionalEmailsApi* | [**smtpLogMessageIdDelete**](docs/Api/TransactionalEmailsApi.md#smtplogmessageiddelete) | **DELETE** /smtp/log/{messageId} | Delete an SMTP transactional log
+*TransactionalEmailsApi* | [**updateSmtpTemplate**](docs/Api/TransactionalEmailsApi.md#updatesmtptemplate) | **PUT** /smtp/templates/{templateId} | Update an email template
 *TransactionalSMSApi* | [**getSmsEvents**](docs/Api/TransactionalSMSApi.md#getsmsevents) | **GET** /transactionalSMS/statistics/events | Get all your SMS activity (unaggregated events)
 *TransactionalSMSApi* | [**getTransacAggregatedSmsReport**](docs/Api/TransactionalSMSApi.md#gettransacaggregatedsmsreport) | **GET** /transactionalSMS/statistics/aggregatedReport | Get your SMS activity aggregated over a period of time
 *TransactionalSMSApi* | [**getTransacSmsReport**](docs/Api/TransactionalSMSApi.md#gettransacsmsreport) | **GET** /transactionalSMS/statistics/reports | Get your SMS activity aggregated per day
@@ -204,6 +204,11 @@ Class | Method | HTTP request | Description
 ## Documentation For Models
 
  - [AbTestCampaignResult](docs/Model/AbTestCampaignResult.md)
+ - [AbTestCampaignResultClickedLinks](docs/Model/AbTestCampaignResultClickedLinks.md)
+ - [AbTestCampaignResultStatistics](docs/Model/AbTestCampaignResultStatistics.md)
+ - [AbTestVersionClicks](docs/Model/AbTestVersionClicks.md)
+ - [AbTestVersionClicksInner](docs/Model/AbTestVersionClicksInner.md)
+ - [AbTestVersionStats](docs/Model/AbTestVersionStats.md)
  - [AddChildDomain](docs/Model/AddChildDomain.md)
  - [AddContactToList](docs/Model/AddContactToList.md)
  - [AddCredits](docs/Model/AddCredits.md)

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.x.x-dev"
+            "dev-master": "7.x.x-dev"
         }
     }
 }

--- a/docs/Api/ContactsApi.md
+++ b/docs/Api/ContactsApi.md
@@ -11,12 +11,12 @@ Method | HTTP request | Description
 [**createFolder**](ContactsApi.md#createFolder) | **POST** /contacts/folders | Create a folder
 [**createList**](ContactsApi.md#createList) | **POST** /contacts/lists | Create a list
 [**deleteAttribute**](ContactsApi.md#deleteAttribute) | **DELETE** /contacts/attributes/{attributeCategory}/{attributeName} | Delete an attribute
-[**deleteContact**](ContactsApi.md#deleteContact) | **DELETE** /contacts/{email} | Delete a contact
+[**deleteContact**](ContactsApi.md#deleteContact) | **DELETE** /contacts/{identifier} | Delete a contact
 [**deleteFolder**](ContactsApi.md#deleteFolder) | **DELETE** /contacts/folders/{folderId} | Delete a folder (and all its lists)
 [**deleteList**](ContactsApi.md#deleteList) | **DELETE** /contacts/lists/{listId} | Delete a list
 [**getAttributes**](ContactsApi.md#getAttributes) | **GET** /contacts/attributes | List all attributes
-[**getContactInfo**](ContactsApi.md#getContactInfo) | **GET** /contacts/{email} | Get a contact&#39;s details
-[**getContactStats**](ContactsApi.md#getContactStats) | **GET** /contacts/{email}/campaignStats | Get email campaigns&#39; statistics for a contact
+[**getContactInfo**](ContactsApi.md#getContactInfo) | **GET** /contacts/{identifier} | Get a contact&#39;s details
+[**getContactStats**](ContactsApi.md#getContactStats) | **GET** /contacts/{identifier}/campaignStats | Get email campaigns&#39; statistics for a contact
 [**getContacts**](ContactsApi.md#getContacts) | **GET** /contacts | Get all the contacts
 [**getContactsFromList**](ContactsApi.md#getContactsFromList) | **GET** /contacts/lists/{listId}/contacts | Get contacts in a list
 [**getFolder**](ContactsApi.md#getFolder) | **GET** /contacts/folders/{folderId} | Returns a folder&#39;s details
@@ -28,7 +28,7 @@ Method | HTTP request | Description
 [**removeContactFromList**](ContactsApi.md#removeContactFromList) | **POST** /contacts/lists/{listId}/contacts/remove | Delete a contact from a list
 [**requestContactExport**](ContactsApi.md#requestContactExport) | **POST** /contacts/export | Export contacts
 [**updateAttribute**](ContactsApi.md#updateAttribute) | **PUT** /contacts/attributes/{attributeCategory}/{attributeName} | Update contact attribute
-[**updateContact**](ContactsApi.md#updateContact) | **PUT** /contacts/{email} | Update a contact
+[**updateContact**](ContactsApi.md#updateContact) | **PUT** /contacts/{identifier} | Update a contact
 [**updateFolder**](ContactsApi.md#updateFolder) | **PUT** /contacts/folders/{folderId} | Update a folder
 [**updateList**](ContactsApi.md#updateList) | **PUT** /contacts/lists/{listId} | Update a list
 
@@ -59,7 +59,7 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
     $config
 );
 $listId = 789; // int | Id of the list
-$contactEmails = new \SendinBlue\Client\Model\AddContactToList(); // \SendinBlue\Client\Model\AddContactToList | Emails addresses of the contacts
+$contactEmails = new \SendinBlue\Client\Model\AddContactToList(); // \SendinBlue\Client\Model\AddContactToList | Emails addresses OR IDs of the contacts
 
 try {
     $result = $apiInstance->addContactToList($listId, $contactEmails);
@@ -75,7 +75,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **listId** | **int**| Id of the list |
- **contactEmails** | [**\SendinBlue\Client\Model\AddContactToList**](../Model/AddContactToList.md)| Emails addresses of the contacts |
+ **contactEmails** | [**\SendinBlue\Client\Model\AddContactToList**](../Model/AddContactToList.md)| Emails addresses OR IDs of the contacts |
 
 ### Return type
 
@@ -438,7 +438,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **deleteContact**
-> deleteContact($email)
+> deleteContact($identifier)
 
 Delete a contact
 
@@ -462,10 +462,10 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
     new GuzzleHttp\Client(),
     $config
 );
-$email = "email_example"; // string | Email (urlencoded) of the contact
+$identifier = "identifier_example"; // string | Email (urlencoded) OR ID of the contact
 
 try {
-    $apiInstance->deleteContact($email);
+    $apiInstance->deleteContact($identifier);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->deleteContact: ', $e->getMessage(), PHP_EOL;
 }
@@ -476,7 +476,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **email** | **string**| Email (urlencoded) of the contact |
+ **identifier** | **string**| Email (urlencoded) OR ID of the contact |
 
 ### Return type
 
@@ -659,7 +659,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getContactInfo**
-> \SendinBlue\Client\Model\GetExtendedContactDetails getContactInfo($email)
+> \SendinBlue\Client\Model\GetExtendedContactDetails getContactInfo($identifier)
 
 Get a contact's details
 
@@ -683,10 +683,10 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
     new GuzzleHttp\Client(),
     $config
 );
-$email = "email_example"; // string | Email (urlencoded) of the contact OR its SMS attribute value
+$identifier = "identifier_example"; // string | Email (urlencoded) OR ID of the contact OR its SMS attribute value
 
 try {
-    $result = $apiInstance->getContactInfo($email);
+    $result = $apiInstance->getContactInfo($identifier);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getContactInfo: ', $e->getMessage(), PHP_EOL;
@@ -698,7 +698,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **email** | **string**| Email (urlencoded) of the contact OR its SMS attribute value |
+ **identifier** | **string**| Email (urlencoded) OR ID of the contact OR its SMS attribute value |
 
 ### Return type
 
@@ -716,7 +716,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getContactStats**
-> \SendinBlue\Client\Model\GetContactCampaignStats getContactStats($email, $startDate, $endDate)
+> \SendinBlue\Client\Model\GetContactCampaignStats getContactStats($identifier, $startDate, $endDate)
 
 Get email campaigns' statistics for a contact
 
@@ -740,12 +740,12 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
     new GuzzleHttp\Client(),
     $config
 );
-$email = "email_example"; // string | Email address (urlencoded) of the contact
+$identifier = "identifier_example"; // string | Email (urlencoded) OR ID of the contact
 $startDate = new \DateTime("2013-10-20"); // \DateTime | Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate
 $endDate = new \DateTime("2013-10-20"); // \DateTime | Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate
 
 try {
-    $result = $apiInstance->getContactStats($email, $startDate, $endDate);
+    $result = $apiInstance->getContactStats($identifier, $startDate, $endDate);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getContactStats: ', $e->getMessage(), PHP_EOL;
@@ -757,7 +757,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **email** | **string**| Email address (urlencoded) of the contact |
+ **identifier** | **string**| Email (urlencoded) OR ID of the contact |
  **startDate** | **\DateTime**| Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate | [optional]
  **endDate** | **\DateTime**| Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate | [optional]
 
@@ -1278,7 +1278,7 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
     $config
 );
 $listId = 789; // int | Id of the list
-$contactEmails = new \SendinBlue\Client\Model\RemoveContactFromList(); // \SendinBlue\Client\Model\RemoveContactFromList | Emails adresses of the contact
+$contactEmails = new \SendinBlue\Client\Model\RemoveContactFromList(); // \SendinBlue\Client\Model\RemoveContactFromList | Emails addresses OR IDs of the contacts
 
 try {
     $result = $apiInstance->removeContactFromList($listId, $contactEmails);
@@ -1294,7 +1294,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **listId** | **int**| Id of the list |
- **contactEmails** | [**\SendinBlue\Client\Model\RemoveContactFromList**](../Model/RemoveContactFromList.md)| Emails adresses of the contact |
+ **contactEmails** | [**\SendinBlue\Client\Model\RemoveContactFromList**](../Model/RemoveContactFromList.md)| Emails addresses OR IDs of the contacts |
 
 ### Return type
 
@@ -1431,7 +1431,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **updateContact**
-> updateContact($email, $updateContact)
+> updateContact($identifier, $updateContact)
 
 Update a contact
 
@@ -1455,11 +1455,11 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
     new GuzzleHttp\Client(),
     $config
 );
-$email = "email_example"; // string | Email (urlencoded) of the contact
+$identifier = "identifier_example"; // string | Email (urlencoded) OR ID of the contact
 $updateContact = new \SendinBlue\Client\Model\UpdateContact(); // \SendinBlue\Client\Model\UpdateContact | Values to update a contact
 
 try {
-    $apiInstance->updateContact($email, $updateContact);
+    $apiInstance->updateContact($identifier, $updateContact);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->updateContact: ', $e->getMessage(), PHP_EOL;
 }
@@ -1470,7 +1470,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **email** | **string**| Email (urlencoded) of the contact |
+ **identifier** | **string**| Email (urlencoded) OR ID of the contact |
  **updateContact** | [**\SendinBlue\Client\Model\UpdateContact**](../Model/UpdateContact.md)| Values to update a contact |
 
 ### Return type

--- a/docs/Api/ListsApi.md
+++ b/docs/Api/ListsApi.md
@@ -41,7 +41,7 @@ $apiInstance = new SendinBlue\Client\Api\ListsApi(
     $config
 );
 $listId = 789; // int | Id of the list
-$contactEmails = new \SendinBlue\Client\Model\AddContactToList(); // \SendinBlue\Client\Model\AddContactToList | Emails addresses of the contacts
+$contactEmails = new \SendinBlue\Client\Model\AddContactToList(); // \SendinBlue\Client\Model\AddContactToList | Emails addresses OR IDs of the contacts
 
 try {
     $result = $apiInstance->addContactToList($listId, $contactEmails);
@@ -57,7 +57,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **listId** | **int**| Id of the list |
- **contactEmails** | [**\SendinBlue\Client\Model\AddContactToList**](../Model/AddContactToList.md)| Emails addresses of the contacts |
+ **contactEmails** | [**\SendinBlue\Client\Model\AddContactToList**](../Model/AddContactToList.md)| Emails addresses OR IDs of the contacts |
 
 ### Return type
 
@@ -453,7 +453,7 @@ $apiInstance = new SendinBlue\Client\Api\ListsApi(
     $config
 );
 $listId = 789; // int | Id of the list
-$contactEmails = new \SendinBlue\Client\Model\RemoveContactFromList(); // \SendinBlue\Client\Model\RemoveContactFromList | Emails adresses of the contact
+$contactEmails = new \SendinBlue\Client\Model\RemoveContactFromList(); // \SendinBlue\Client\Model\RemoveContactFromList | Emails addresses OR IDs of the contacts
 
 try {
     $result = $apiInstance->removeContactFromList($listId, $contactEmails);
@@ -469,7 +469,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **listId** | **int**| Id of the list |
- **contactEmails** | [**\SendinBlue\Client\Model\RemoveContactFromList**](../Model/RemoveContactFromList.md)| Emails adresses of the contact |
+ **contactEmails** | [**\SendinBlue\Client\Model\RemoveContactFromList**](../Model/RemoveContactFromList.md)| Emails addresses OR IDs of the contacts |
 
 ### Return type
 

--- a/docs/Api/TransactionalEmailsApi.md
+++ b/docs/Api/TransactionalEmailsApi.md
@@ -1,26 +1,26 @@
-# SendinBlue\Client\SMTPApi
+# SendinBlue\Client\TransactionalEmailsApi
 
 All URIs are relative to *https://api.sendinblue.com/v3*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**createSmtpTemplate**](SMTPApi.md#createSmtpTemplate) | **POST** /smtp/templates | Create an email template
-[**deleteHardbounces**](SMTPApi.md#deleteHardbounces) | **POST** /smtp/deleteHardbounces | Delete hardbounces
-[**deleteSmtpTemplate**](SMTPApi.md#deleteSmtpTemplate) | **DELETE** /smtp/templates/{templateId} | Delete an inactive email template
-[**getAggregatedSmtpReport**](SMTPApi.md#getAggregatedSmtpReport) | **GET** /smtp/statistics/aggregatedReport | Get your transactional email activity aggregated over a period of time
-[**getEmailEventReport**](SMTPApi.md#getEmailEventReport) | **GET** /smtp/statistics/events | Get all your transactional email activity (unaggregated events)
-[**getSmtpReport**](SMTPApi.md#getSmtpReport) | **GET** /smtp/statistics/reports | Get your transactional email activity aggregated per day
-[**getSmtpTemplate**](SMTPApi.md#getSmtpTemplate) | **GET** /smtp/templates/{templateId} | Returns the template information
-[**getSmtpTemplates**](SMTPApi.md#getSmtpTemplates) | **GET** /smtp/templates | Get the list of email templates
-[**getTransacBlockedContacts**](SMTPApi.md#getTransacBlockedContacts) | **GET** /smtp/blockedContacts | Get the list of blocked or unsubscribed transactional contacts
-[**getTransacEmailContent**](SMTPApi.md#getTransacEmailContent) | **GET** /smtp/emails/{uuid} | Get the personalized content of a sent transactional email
-[**getTransacEmailsList**](SMTPApi.md#getTransacEmailsList) | **GET** /smtp/emails | Get the list of transactional emails on the basis of allowed filters
-[**sendTemplate**](SMTPApi.md#sendTemplate) | **POST** /smtp/templates/{templateId}/send | Send a template
-[**sendTestTemplate**](SMTPApi.md#sendTestTemplate) | **POST** /smtp/templates/{templateId}/sendTest | Send a template to your test list
-[**sendTransacEmail**](SMTPApi.md#sendTransacEmail) | **POST** /smtp/email | Send a transactional email
-[**smtpBlockedContactsEmailDelete**](SMTPApi.md#smtpBlockedContactsEmailDelete) | **DELETE** /smtp/blockedContacts/{email} | Unblock or resubscribe a transactional contact
-[**smtpLogMessageIdDelete**](SMTPApi.md#smtpLogMessageIdDelete) | **DELETE** /smtp/log/{messageId} | Delete an SMTP transactional log
-[**updateSmtpTemplate**](SMTPApi.md#updateSmtpTemplate) | **PUT** /smtp/templates/{templateId} | Update an email template
+[**createSmtpTemplate**](TransactionalEmailsApi.md#createSmtpTemplate) | **POST** /smtp/templates | Create an email template
+[**deleteHardbounces**](TransactionalEmailsApi.md#deleteHardbounces) | **POST** /smtp/deleteHardbounces | Delete hardbounces
+[**deleteSmtpTemplate**](TransactionalEmailsApi.md#deleteSmtpTemplate) | **DELETE** /smtp/templates/{templateId} | Delete an inactive email template
+[**getAggregatedSmtpReport**](TransactionalEmailsApi.md#getAggregatedSmtpReport) | **GET** /smtp/statistics/aggregatedReport | Get your transactional email activity aggregated over a period of time
+[**getEmailEventReport**](TransactionalEmailsApi.md#getEmailEventReport) | **GET** /smtp/statistics/events | Get all your transactional email activity (unaggregated events)
+[**getSmtpReport**](TransactionalEmailsApi.md#getSmtpReport) | **GET** /smtp/statistics/reports | Get your transactional email activity aggregated per day
+[**getSmtpTemplate**](TransactionalEmailsApi.md#getSmtpTemplate) | **GET** /smtp/templates/{templateId} | Returns the template information
+[**getSmtpTemplates**](TransactionalEmailsApi.md#getSmtpTemplates) | **GET** /smtp/templates | Get the list of email templates
+[**getTransacBlockedContacts**](TransactionalEmailsApi.md#getTransacBlockedContacts) | **GET** /smtp/blockedContacts | Get the list of blocked or unsubscribed transactional contacts
+[**getTransacEmailContent**](TransactionalEmailsApi.md#getTransacEmailContent) | **GET** /smtp/emails/{uuid} | Get the personalized content of a sent transactional email
+[**getTransacEmailsList**](TransactionalEmailsApi.md#getTransacEmailsList) | **GET** /smtp/emails | Get the list of transactional emails on the basis of allowed filters
+[**sendTemplate**](TransactionalEmailsApi.md#sendTemplate) | **POST** /smtp/templates/{templateId}/send | Send a template
+[**sendTestTemplate**](TransactionalEmailsApi.md#sendTestTemplate) | **POST** /smtp/templates/{templateId}/sendTest | Send a template to your test list
+[**sendTransacEmail**](TransactionalEmailsApi.md#sendTransacEmail) | **POST** /smtp/email | Send a transactional email
+[**smtpBlockedContactsEmailDelete**](TransactionalEmailsApi.md#smtpBlockedContactsEmailDelete) | **DELETE** /smtp/blockedContacts/{email} | Unblock or resubscribe a transactional contact
+[**smtpLogMessageIdDelete**](TransactionalEmailsApi.md#smtpLogMessageIdDelete) | **DELETE** /smtp/log/{messageId} | Delete an SMTP transactional log
+[**updateSmtpTemplate**](TransactionalEmailsApi.md#updateSmtpTemplate) | **PUT** /smtp/templates/{templateId} | Update an email template
 
 
 # **createSmtpTemplate**
@@ -42,7 +42,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -54,7 +54,7 @@ try {
     $result = $apiInstance->createSmtpTemplate($smtpTemplate);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->createSmtpTemplate: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->createSmtpTemplate: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -101,7 +101,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -112,7 +112,7 @@ $deleteHardbounces = new \SendinBlue\Client\Model\DeleteHardbounces(); // \Sendi
 try {
     $apiInstance->deleteHardbounces($deleteHardbounces);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->deleteHardbounces: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->deleteHardbounces: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -157,7 +157,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -168,7 +168,7 @@ $templateId = 789; // int | id of the template
 try {
     $apiInstance->deleteSmtpTemplate($templateId);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->deleteSmtpTemplate: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->deleteSmtpTemplate: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -213,7 +213,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -228,7 +228,7 @@ try {
     $result = $apiInstance->getAggregatedSmtpReport($startDate, $endDate, $days, $tag);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getAggregatedSmtpReport: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getAggregatedSmtpReport: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -276,7 +276,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -297,7 +297,7 @@ try {
     $result = $apiInstance->getEmailEventReport($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getEmailEventReport: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getEmailEventReport: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -351,7 +351,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -368,7 +368,7 @@ try {
     $result = $apiInstance->getSmtpReport($limit, $offset, $startDate, $endDate, $days, $tag);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getSmtpReport: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getSmtpReport: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -418,7 +418,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -430,7 +430,7 @@ try {
     $result = $apiInstance->getSmtpTemplate($templateId);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getSmtpTemplate: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getSmtpTemplate: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -475,7 +475,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -489,7 +489,7 @@ try {
     $result = $apiInstance->getSmtpTemplates($templateStatus, $limit, $offset);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getSmtpTemplates: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getSmtpTemplates: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -536,7 +536,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -552,7 +552,7 @@ try {
     $result = $apiInstance->getTransacBlockedContacts($startDate, $endDate, $limit, $offset, $senders);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getTransacBlockedContacts: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getTransacBlockedContacts: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -601,7 +601,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -613,7 +613,7 @@ try {
     $result = $apiInstance->getTransacEmailContent($uuid);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getTransacEmailContent: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getTransacEmailContent: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -660,7 +660,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -676,7 +676,7 @@ try {
     $result = $apiInstance->getTransacEmailsList($email, $templateId, $messageId, $startDate, $endDate);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->getTransacEmailsList: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->getTransacEmailsList: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -727,7 +727,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -740,7 +740,7 @@ try {
     $result = $apiInstance->sendTemplate($templateId, $sendEmail);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->sendTemplate: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->sendTemplate: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -786,7 +786,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -798,7 +798,7 @@ $sendTestEmail = new \SendinBlue\Client\Model\SendTestEmail(); // \SendinBlue\Cl
 try {
     $apiInstance->sendTestTemplate($templateId, $sendTestEmail);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->sendTestTemplate: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->sendTestTemplate: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -844,7 +844,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -856,7 +856,7 @@ try {
     $result = $apiInstance->sendTransacEmail($sendSmtpEmail);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->sendTransacEmail: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->sendTransacEmail: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -901,7 +901,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -912,7 +912,7 @@ $email = "email_example"; // string | contact email (urlencoded) to unblock.
 try {
     $apiInstance->smtpBlockedContactsEmailDelete($email);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->smtpBlockedContactsEmailDelete: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->smtpBlockedContactsEmailDelete: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -957,7 +957,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -968,7 +968,7 @@ $messageId = "messageId_example"; // string | MessageId of the transactional log
 try {
     $apiInstance->smtpLogMessageIdDelete($messageId);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->smtpLogMessageIdDelete: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->smtpLogMessageIdDelete: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```
@@ -1013,7 +1013,7 @@ $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey(
 // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 // $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
 
-$apiInstance = new SendinBlue\Client\Api\SMTPApi(
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
@@ -1025,7 +1025,7 @@ $smtpTemplate = new \SendinBlue\Client\Model\UpdateSmtpTemplate(); // \SendinBlu
 try {
     $apiInstance->updateSmtpTemplate($templateId, $smtpTemplate);
 } catch (Exception $e) {
-    echo 'Exception when calling SMTPApi->updateSmtpTemplate: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling TransactionalEmailsApi->updateSmtpTemplate: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```

--- a/docs/Model/AbTestCampaignResult.md
+++ b/docs/Model/AbTestCampaignResult.md
@@ -9,6 +9,9 @@ Name | Type | Description | Notes
 **openRate** | **string** | Open rate for current winning version | [optional] 
 **clickRate** | **string** | Click rate for current winning version | [optional] 
 **winningVersionRate** | **string** | Open/Click rate for the winner version | [optional] 
+**statistics** | [**\SendinBlue\Client\Model\AbTestCampaignResultStatistics**](AbTestCampaignResultStatistics.md) |  | [optional] 
+**clickedLinks** | [**\SendinBlue\Client\Model\AbTestCampaignResultClickedLinks**](AbTestCampaignResultClickedLinks.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
 

--- a/docs/Model/AbTestCampaignResultClickedLinks.md
+++ b/docs/Model/AbTestCampaignResultClickedLinks.md
@@ -1,10 +1,10 @@
-# GetTransacEmailContentEvents
+# AbTestCampaignResultClickedLinks
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **string** | Name of the event that occurred on the sent email | 
-**time** | [**\DateTime**] | Time at which the event occurred | 
+**versionA** | [**\SendinBlue\Client\Model\AbTestVersionClicks**](AbTestVersionClicks.md) |  | 
+**versionB** | [**\SendinBlue\Client\Model\AbTestVersionClicks**](AbTestVersionClicks.md) |  | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/AbTestCampaignResultStatistics.md
+++ b/docs/Model/AbTestCampaignResultStatistics.md
@@ -1,0 +1,15 @@
+# AbTestCampaignResultStatistics
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**openers** | [**\SendinBlue\Client\Model\AbTestVersionStats**](AbTestVersionStats.md) |  | 
+**clicks** | [**\SendinBlue\Client\Model\AbTestVersionStats**](AbTestVersionStats.md) |  | 
+**unsubscribed** | [**\SendinBlue\Client\Model\AbTestVersionStats**](AbTestVersionStats.md) |  | 
+**hardBounces** | [**\SendinBlue\Client\Model\AbTestVersionStats**](AbTestVersionStats.md) |  | 
+**softBounces** | [**\SendinBlue\Client\Model\AbTestVersionStats**](AbTestVersionStats.md) |  | 
+**complaints** | [**\SendinBlue\Client\Model\AbTestVersionStats**](AbTestVersionStats.md) |  | 
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/AbTestVersionClicks.md
+++ b/docs/Model/AbTestVersionClicks.md
@@ -1,10 +1,8 @@
-# GetTransacEmailContentEvents
+# AbTestVersionClicks
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **string** | Name of the event that occurred on the sent email | 
-**time** | [**\DateTime**] | Time at which the event occurred | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/AbTestVersionClicksInner.md
+++ b/docs/Model/AbTestVersionClicksInner.md
@@ -1,10 +1,11 @@
-# GetTransacEmailContentEvents
+# AbTestVersionClicksInner
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **string** | Name of the event that occurred on the sent email | 
-**time** | [**\DateTime**] | Time at which the event occurred | 
+**link** | **string** | URL of the link | 
+**clicksCount** | **float** | Number of times a link is clicked | 
+**clickRate** | **string** | Percentage of clicks of link with respect to total clicks | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/AbTestVersionStats.md
+++ b/docs/Model/AbTestVersionStats.md
@@ -1,10 +1,10 @@
-# GetTransacEmailContentEvents
+# AbTestVersionStats
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **string** | Name of the event that occurred on the sent email | 
-**time** | [**\DateTime**] | Time at which the event occurred | 
+**versionA** | **string** | percentage of an event for version A | 
+**versionB** | **string** | percentage of an event for version B | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/AddContactToList.md
+++ b/docs/Model/AddContactToList.md
@@ -3,7 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**emails** | **string[]** | Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api. | [optional] 
+**emails** | **string[]** | Mandatory if IDs are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api. | [optional] 
+**ids** | **int[]** | Mandatory if Emails are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/CreateDoiContact.md
+++ b/docs/Model/CreateDoiContact.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **includeListIds** | **int[]** | Lists under user account where contact should be added | 
 **excludeListIds** | **int[]** | Lists under user account where contact should not be added | [optional] 
 **templateId** | **int** | Id of the Double opt-in (DOI) template | 
-**redirectionUrl** | **string** | URL of the web page that user will be redirected to after clicking on the double opt in URL. When editing your DOI template you can reference this URL by using the tag {{ params.DOIurl }}. | [optional] 
+**redirectionUrl** | **string** | URL of the web page that user will be redirected to after clicking on the double opt in URL. When editing your DOI template you can reference this URL by using the tag {{ params.DOIurl }}. | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetAggregatedReport.md
+++ b/docs/Model/GetAggregatedReport.md
@@ -3,19 +3,19 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**range** | **string** | Time frame of the report | 
-**requests** | **int** | Number of requests for the timeframe | 
-**delivered** | **int** | Number of delivered emails for the timeframe | 
-**hardBounces** | **int** | Number of hardbounces for the timeframe | 
-**softBounces** | **int** | Number of softbounces for the timeframe | 
-**clicks** | **int** | Number of clicks for the timeframe | 
-**uniqueClicks** | **int** | Number of unique clicks for the timeframe | 
-**opens** | **int** | Number of openings for the timeframe | 
-**uniqueOpens** | **int** | Number of unique openings for the timeframe | 
-**spamReports** | **int** | Number of complaint (spam report) for the timeframe | 
-**blocked** | **int** | Number of blocked contact emails for the timeframe | 
-**invalid** | **int** | Number of invalid emails for the timeframe | 
-**unsubscribed** | **int** | Number of unsubscribed emails for the timeframe | 
+**range** | **string** | Time frame of the report | [optional] 
+**requests** | **int** | Number of requests for the timeframe | [optional] 
+**delivered** | **int** | Number of delivered emails for the timeframe | [optional] 
+**hardBounces** | **int** | Number of hardbounces for the timeframe | [optional] 
+**softBounces** | **int** | Number of softbounces for the timeframe | [optional] 
+**clicks** | **int** | Number of clicks for the timeframe | [optional] 
+**uniqueClicks** | **int** | Number of unique clicks for the timeframe | [optional] 
+**opens** | **int** | Number of openings for the timeframe | [optional] 
+**uniqueOpens** | **int** | Number of unique openings for the timeframe | [optional] 
+**spamReports** | **int** | Number of complaint (spam report) for the timeframe | [optional] 
+**blocked** | **int** | Number of blocked contact emails for the timeframe | [optional] 
+**invalid** | **int** | Number of invalid emails for the timeframe | [optional] 
+**unsubscribed** | **int** | Number of unsubscribed emails for the timeframe | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetCampaignStats.md
+++ b/docs/Model/GetCampaignStats.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **unsubscriptions** | **int** | Number of unsubscription for the campaign | 
 **viewed** | **int** | Number of openings for the campaign | 
 **deferred** | **int** | Number of deferred emails for the campaign | [optional] 
+**returnBounce** | **int** | Total number of non-delivered campaigns for a particular campaign id. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetEmailCampaign.md
+++ b/docs/Model/GetEmailCampaign.md
@@ -30,7 +30,7 @@ Name | Type | Description | Notes
 **inlineImageActivation** | **bool** | Status of inline image. inlineImageActivation &#x3D; false means image can’t be embedded, &amp; inlineImageActivation &#x3D; true means image can be embedded, in the email. | [optional] 
 **mirrorActive** | **bool** | Status of mirror links in campaign. mirrorActive &#x3D; false means mirror links are deactivated, &amp; mirrorActive &#x3D; true means mirror links are activated, in the campaign | [optional] 
 **recurring** | **bool** | FOR TRIGGER ONLY ! Type of trigger campaign.recurring &#x3D; false means contact can receive the same Trigger campaign only once, &amp; recurring &#x3D; true means contact can receive the same Trigger campaign several times | [optional] 
-**sentDate** | [**\DateTime**](\DateTime.md) | Sent UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ). Only available if &#39;status&#39; of the campaign is &#39;sent&#39; | [optional] 
+**sentDate** | [**\DateTime**] | Sent UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ). Only available if &#39;status&#39; of the campaign is &#39;sent&#39; | [optional] 
 **returnBounce** | **int** | Total number of non-delivered campaigns for a particular campaign id. | [optional] 
 **recipients** | **object** |  | 
 **statistics** | **object** |  | 

--- a/docs/Model/GetTransacBlockedContactsContacts.md
+++ b/docs/Model/GetTransacBlockedContactsContacts.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **email** | **string** | Email address of the blocked or unsubscribed contact | 
 **senderEmail** | **string** | Sender email address of the blocked or unsubscribed contact | 
 **reason** | [**\SendinBlue\Client\Model\GetTransacBlockedContactsReason**](GetTransacBlockedContactsReason.md) |  | 
-**blockedAt** | [**\DateTime**](\DateTime.md) | Date when the contact was blocked or unsubscribed on | 
+**blockedAt** | [**\DateTime**] | Date when the contact was blocked or unsubscribed on | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/RemoveContactFromList.md
+++ b/docs/Model/RemoveContactFromList.md
@@ -4,7 +4,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **emails** | **string[]** | Required if &#39;all&#39; is false. Emails to remove from a list. You can pass a maximum of 150 emails for removal in one request. | [optional] 
-**all** | **bool** | Required if &#39;emails&#39; is empty. Remove all existing contacts from a list.  A process will be created in this scenario. You can fetch the process details to know about the progress | [optional] 
+**ids** | **int[]** | Mandatory if Emails are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api. | [optional] 
+**all** | **bool** | Required if none of &#39;emails&#39; or &#39;ids&#39; are passed. Remove all existing contacts from a list.  A process will be created in this scenario. You can fetch the process details to know about the progress | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/RequestSMSRecipientExport.md
+++ b/docs/Model/RequestSMSRecipientExport.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**notifyURL** | **string** | URL that will be called once the export process is finished | [optional] 
+**notifyURL** | **string** | URL that will be called once the export process is finished. For reference, https://help.sendinblue.com/hc/en-us/articles/360007666479 | [optional] 
 **recipientsType** | **string** | Filter the recipients based on how they interacted with the campaign | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/docs/Model/SendSmtpEmailSender.md
+++ b/docs/Model/SendSmtpEmailSender.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **string** | Name of the sender from which the emails will be sent. Maximum allowed characters are 70. | [optional] 
 **email** | **string** | Email of the sender from which the emails will be sent | 
+**id** | **int** | Id of the sender from which the emails will be sent | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/lib/Api/ContactsApi.php
+++ b/lib/Api/ContactsApi.php
@@ -93,7 +93,7 @@ class ContactsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -111,7 +111,7 @@ class ContactsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -203,7 +203,7 @@ class ContactsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -224,7 +224,7 @@ class ContactsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -275,7 +275,7 @@ class ContactsApi
      * Create request for operation 'addContactToList'
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -2060,15 +2060,15 @@ class ContactsApi
      *
      * Delete a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deleteContact($email)
+    public function deleteContact($identifier)
     {
-        $this->deleteContactWithHttpInfo($email);
+        $this->deleteContactWithHttpInfo($identifier);
     }
 
     /**
@@ -2076,16 +2076,16 @@ class ContactsApi
      *
      * Delete a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteContactWithHttpInfo($email)
+    public function deleteContactWithHttpInfo($identifier)
     {
         $returnType = '';
-        $request = $this->deleteContactRequest($email);
+        $request = $this->deleteContactRequest($identifier);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2153,14 +2153,14 @@ class ContactsApi
      *
      * Delete a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteContactAsync($email)
+    public function deleteContactAsync($identifier)
     {
-        return $this->deleteContactAsyncWithHttpInfo($email)
+        return $this->deleteContactAsyncWithHttpInfo($identifier)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2173,15 +2173,15 @@ class ContactsApi
      *
      * Delete a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteContactAsyncWithHttpInfo($email)
+    public function deleteContactAsyncWithHttpInfo($identifier)
     {
         $returnType = '';
-        $request = $this->deleteContactRequest($email);
+        $request = $this->deleteContactRequest($identifier);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2209,21 +2209,21 @@ class ContactsApi
     /**
      * Create request for operation 'deleteContact'
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function deleteContactRequest($email)
+    protected function deleteContactRequest($identifier)
     {
-        // verify the required parameter 'email' is set
-        if ($email === null || (is_array($email) && count($email) === 0)) {
+        // verify the required parameter 'identifier' is set
+        if ($identifier === null || (is_array($identifier) && count($identifier) === 0)) {
             throw new \InvalidArgumentException(
-                'Missing the required parameter $email when calling deleteContact'
+                'Missing the required parameter $identifier when calling deleteContact'
             );
         }
 
-        $resourcePath = '/contacts/{email}';
+        $resourcePath = '/contacts/{identifier}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -2232,10 +2232,10 @@ class ContactsApi
 
 
         // path params
-        if ($email !== null) {
+        if ($identifier !== null) {
             $resourcePath = str_replace(
-                '{' . 'email' . '}',
-                ObjectSerializer::toPathValue($email),
+                '{' . 'identifier' . '}',
+                ObjectSerializer::toPathValue($identifier),
                 $resourcePath
             );
         }
@@ -3102,15 +3102,15 @@ class ContactsApi
      *
      * Get a contact's details
      *
-     * @param  string $email Email (urlencoded) of the contact OR its SMS attribute value (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact OR its SMS attribute value (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetExtendedContactDetails
      */
-    public function getContactInfo($email)
+    public function getContactInfo($identifier)
     {
-        list($response) = $this->getContactInfoWithHttpInfo($email);
+        list($response) = $this->getContactInfoWithHttpInfo($identifier);
         return $response;
     }
 
@@ -3119,16 +3119,16 @@ class ContactsApi
      *
      * Get a contact's details
      *
-     * @param  string $email Email (urlencoded) of the contact OR its SMS attribute value (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact OR its SMS attribute value (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetExtendedContactDetails, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getContactInfoWithHttpInfo($email)
+    public function getContactInfoWithHttpInfo($identifier)
     {
         $returnType = '\SendinBlue\Client\Model\GetExtendedContactDetails';
-        $request = $this->getContactInfoRequest($email);
+        $request = $this->getContactInfoRequest($identifier);
 
         try {
             $options = $this->createHttpClientOption();
@@ -3210,14 +3210,14 @@ class ContactsApi
      *
      * Get a contact's details
      *
-     * @param  string $email Email (urlencoded) of the contact OR its SMS attribute value (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact OR its SMS attribute value (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactInfoAsync($email)
+    public function getContactInfoAsync($identifier)
     {
-        return $this->getContactInfoAsyncWithHttpInfo($email)
+        return $this->getContactInfoAsyncWithHttpInfo($identifier)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -3230,15 +3230,15 @@ class ContactsApi
      *
      * Get a contact's details
      *
-     * @param  string $email Email (urlencoded) of the contact OR its SMS attribute value (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact OR its SMS attribute value (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactInfoAsyncWithHttpInfo($email)
+    public function getContactInfoAsyncWithHttpInfo($identifier)
     {
         $returnType = '\SendinBlue\Client\Model\GetExtendedContactDetails';
-        $request = $this->getContactInfoRequest($email);
+        $request = $this->getContactInfoRequest($identifier);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -3280,21 +3280,21 @@ class ContactsApi
     /**
      * Create request for operation 'getContactInfo'
      *
-     * @param  string $email Email (urlencoded) of the contact OR its SMS attribute value (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact OR its SMS attribute value (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getContactInfoRequest($email)
+    protected function getContactInfoRequest($identifier)
     {
-        // verify the required parameter 'email' is set
-        if ($email === null || (is_array($email) && count($email) === 0)) {
+        // verify the required parameter 'identifier' is set
+        if ($identifier === null || (is_array($identifier) && count($identifier) === 0)) {
             throw new \InvalidArgumentException(
-                'Missing the required parameter $email when calling getContactInfo'
+                'Missing the required parameter $identifier when calling getContactInfo'
             );
         }
 
-        $resourcePath = '/contacts/{email}';
+        $resourcePath = '/contacts/{identifier}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -3303,10 +3303,10 @@ class ContactsApi
 
 
         // path params
-        if ($email !== null) {
+        if ($identifier !== null) {
             $resourcePath = str_replace(
-                '{' . 'email' . '}',
-                ObjectSerializer::toPathValue($email),
+                '{' . 'identifier' . '}',
+                ObjectSerializer::toPathValue($identifier),
                 $resourcePath
             );
         }
@@ -3397,7 +3397,7 @@ class ContactsApi
      *
      * Get email campaigns' statistics for a contact
      *
-     * @param  string $email Email address (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate (optional)
      *
@@ -3405,9 +3405,9 @@ class ContactsApi
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetContactCampaignStats
      */
-    public function getContactStats($email, $startDate = null, $endDate = null)
+    public function getContactStats($identifier, $startDate = null, $endDate = null)
     {
-        list($response) = $this->getContactStatsWithHttpInfo($email, $startDate, $endDate);
+        list($response) = $this->getContactStatsWithHttpInfo($identifier, $startDate, $endDate);
         return $response;
     }
 
@@ -3416,7 +3416,7 @@ class ContactsApi
      *
      * Get email campaigns' statistics for a contact
      *
-     * @param  string $email Email address (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate (optional)
      *
@@ -3424,10 +3424,10 @@ class ContactsApi
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetContactCampaignStats, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getContactStatsWithHttpInfo($email, $startDate = null, $endDate = null)
+    public function getContactStatsWithHttpInfo($identifier, $startDate = null, $endDate = null)
     {
         $returnType = '\SendinBlue\Client\Model\GetContactCampaignStats';
-        $request = $this->getContactStatsRequest($email, $startDate, $endDate);
+        $request = $this->getContactStatsRequest($identifier, $startDate, $endDate);
 
         try {
             $options = $this->createHttpClientOption();
@@ -3509,16 +3509,16 @@ class ContactsApi
      *
      * Get email campaigns' statistics for a contact
      *
-     * @param  string $email Email address (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactStatsAsync($email, $startDate = null, $endDate = null)
+    public function getContactStatsAsync($identifier, $startDate = null, $endDate = null)
     {
-        return $this->getContactStatsAsyncWithHttpInfo($email, $startDate, $endDate)
+        return $this->getContactStatsAsyncWithHttpInfo($identifier, $startDate, $endDate)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -3531,17 +3531,17 @@ class ContactsApi
      *
      * Get email campaigns' statistics for a contact
      *
-     * @param  string $email Email address (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactStatsAsyncWithHttpInfo($email, $startDate = null, $endDate = null)
+    public function getContactStatsAsyncWithHttpInfo($identifier, $startDate = null, $endDate = null)
     {
         $returnType = '\SendinBlue\Client\Model\GetContactCampaignStats';
-        $request = $this->getContactStatsRequest($email, $startDate, $endDate);
+        $request = $this->getContactStatsRequest($identifier, $startDate, $endDate);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -3583,23 +3583,23 @@ class ContactsApi
     /**
      * Create request for operation 'getContactStats'
      *
-     * @param  string $email Email address (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getContactStatsRequest($email, $startDate = null, $endDate = null)
+    protected function getContactStatsRequest($identifier, $startDate = null, $endDate = null)
     {
-        // verify the required parameter 'email' is set
-        if ($email === null || (is_array($email) && count($email) === 0)) {
+        // verify the required parameter 'identifier' is set
+        if ($identifier === null || (is_array($identifier) && count($identifier) === 0)) {
             throw new \InvalidArgumentException(
-                'Missing the required parameter $email when calling getContactStats'
+                'Missing the required parameter $identifier when calling getContactStats'
             );
         }
 
-        $resourcePath = '/contacts/{email}/campaignStats';
+        $resourcePath = '/contacts/{identifier}/campaignStats';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -3616,10 +3616,10 @@ class ContactsApi
         }
 
         // path params
-        if ($email !== null) {
+        if ($identifier !== null) {
             $resourcePath = str_replace(
-                '{' . 'email' . '}',
-                ObjectSerializer::toPathValue($email),
+                '{' . 'identifier' . '}',
+                ObjectSerializer::toPathValue($identifier),
                 $resourcePath
             );
         }
@@ -6117,7 +6117,7 @@ class ContactsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -6135,7 +6135,7 @@ class ContactsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -6227,7 +6227,7 @@ class ContactsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -6248,7 +6248,7 @@ class ContactsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -6299,7 +6299,7 @@ class ContactsApi
      * Create request for operation 'removeContactFromList'
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -6998,16 +6998,16 @@ class ContactsApi
      *
      * Update a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \SendinBlue\Client\Model\UpdateContact $updateContact Values to update a contact (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updateContact($email, $updateContact)
+    public function updateContact($identifier, $updateContact)
     {
-        $this->updateContactWithHttpInfo($email, $updateContact);
+        $this->updateContactWithHttpInfo($identifier, $updateContact);
     }
 
     /**
@@ -7015,17 +7015,17 @@ class ContactsApi
      *
      * Update a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \SendinBlue\Client\Model\UpdateContact $updateContact Values to update a contact (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updateContactWithHttpInfo($email, $updateContact)
+    public function updateContactWithHttpInfo($identifier, $updateContact)
     {
         $returnType = '';
-        $request = $this->updateContactRequest($email, $updateContact);
+        $request = $this->updateContactRequest($identifier, $updateContact);
 
         try {
             $options = $this->createHttpClientOption();
@@ -7085,15 +7085,15 @@ class ContactsApi
      *
      * Update a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \SendinBlue\Client\Model\UpdateContact $updateContact Values to update a contact (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updateContactAsync($email, $updateContact)
+    public function updateContactAsync($identifier, $updateContact)
     {
-        return $this->updateContactAsyncWithHttpInfo($email, $updateContact)
+        return $this->updateContactAsyncWithHttpInfo($identifier, $updateContact)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -7106,16 +7106,16 @@ class ContactsApi
      *
      * Update a contact
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \SendinBlue\Client\Model\UpdateContact $updateContact Values to update a contact (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updateContactAsyncWithHttpInfo($email, $updateContact)
+    public function updateContactAsyncWithHttpInfo($identifier, $updateContact)
     {
         $returnType = '';
-        $request = $this->updateContactRequest($email, $updateContact);
+        $request = $this->updateContactRequest($identifier, $updateContact);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -7143,18 +7143,18 @@ class ContactsApi
     /**
      * Create request for operation 'updateContact'
      *
-     * @param  string $email Email (urlencoded) of the contact (required)
+     * @param  string $identifier Email (urlencoded) OR ID of the contact (required)
      * @param  \SendinBlue\Client\Model\UpdateContact $updateContact Values to update a contact (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function updateContactRequest($email, $updateContact)
+    protected function updateContactRequest($identifier, $updateContact)
     {
-        // verify the required parameter 'email' is set
-        if ($email === null || (is_array($email) && count($email) === 0)) {
+        // verify the required parameter 'identifier' is set
+        if ($identifier === null || (is_array($identifier) && count($identifier) === 0)) {
             throw new \InvalidArgumentException(
-                'Missing the required parameter $email when calling updateContact'
+                'Missing the required parameter $identifier when calling updateContact'
             );
         }
         // verify the required parameter 'updateContact' is set
@@ -7164,7 +7164,7 @@ class ContactsApi
             );
         }
 
-        $resourcePath = '/contacts/{email}';
+        $resourcePath = '/contacts/{identifier}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -7173,10 +7173,10 @@ class ContactsApi
 
 
         // path params
-        if ($email !== null) {
+        if ($identifier !== null) {
             $resourcePath = str_replace(
-                '{' . 'email' . '}',
-                ObjectSerializer::toPathValue($email),
+                '{' . 'identifier' . '}',
+                ObjectSerializer::toPathValue($identifier),
                 $resourcePath
             );
         }

--- a/lib/Api/ListsApi.php
+++ b/lib/Api/ListsApi.php
@@ -93,7 +93,7 @@ class ListsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -111,7 +111,7 @@ class ListsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -203,7 +203,7 @@ class ListsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -224,7 +224,7 @@ class ListsApi
      * Add existing contacts to a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -275,7 +275,7 @@ class ListsApi
      * Create request for operation 'addContactToList'
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses of the contacts (required)
+     * @param  \SendinBlue\Client\Model\AddContactToList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -2170,7 +2170,7 @@ class ListsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -2188,7 +2188,7 @@ class ListsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -2280,7 +2280,7 @@ class ListsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -2301,7 +2301,7 @@ class ListsApi
      * Delete a contact from a list
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -2352,7 +2352,7 @@ class ListsApi
      * Create request for operation 'removeContactFromList'
      *
      * @param  int $listId Id of the list (required)
-     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails adresses of the contact (required)
+     * @param  \SendinBlue\Client\Model\RemoveContactFromList $contactEmails Emails addresses OR IDs of the contacts (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request

--- a/lib/Api/TransactionalEmailsApi.php
+++ b/lib/Api/TransactionalEmailsApi.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SMTPApi
+ * TransactionalEmailsApi
  * PHP version 5
  *
  * @category Class
@@ -40,14 +40,14 @@ use SendinBlue\Client\HeaderSelector;
 use SendinBlue\Client\ObjectSerializer;
 
 /**
- * SMTPApi Class Doc Comment
+ * TransactionalEmailsApi Class Doc Comment
  *
  * @category Class
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SMTPApi
+class TransactionalEmailsApi
 {
     /**
      * @var ClientInterface
@@ -1398,7 +1398,7 @@ class SMTPApi
     protected function getEmailEventReportRequest($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null)
     {
         if ($limit !== null && $limit > 100) {
-            throw new \InvalidArgumentException('invalid value for "$limit" when calling SMTPApi.getEmailEventReport, must be smaller than or equal to 100.');
+            throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getEmailEventReport, must be smaller than or equal to 100.');
         }
 
 
@@ -1740,7 +1740,7 @@ class SMTPApi
     protected function getSmtpReportRequest($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null)
     {
         if ($limit !== null && $limit > 30) {
-            throw new \InvalidArgumentException('invalid value for "$limit" when calling SMTPApi.getSmtpReport, must be smaller than or equal to 30.');
+            throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getSmtpReport, must be smaller than or equal to 30.');
         }
 
 
@@ -2346,7 +2346,7 @@ class SMTPApi
     protected function getSmtpTemplatesRequest($templateStatus = null, $limit = '50', $offset = '0')
     {
         if ($limit !== null && $limit > 1000) {
-            throw new \InvalidArgumentException('invalid value for "$limit" when calling SMTPApi.getSmtpTemplates, must be smaller than or equal to 1000.');
+            throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getSmtpTemplates, must be smaller than or equal to 1000.');
         }
 
 
@@ -2655,7 +2655,7 @@ class SMTPApi
     protected function getTransacBlockedContactsRequest($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null)
     {
         if ($limit !== null && $limit > 100) {
-            throw new \InvalidArgumentException('invalid value for "$limit" when calling SMTPApi.getTransacBlockedContacts, must be smaller than or equal to 100.');
+            throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getTransacBlockedContacts, must be smaller than or equal to 100.');
         }
 
 

--- a/lib/Model/AbTestCampaignResult.php
+++ b/lib/Model/AbTestCampaignResult.php
@@ -62,7 +62,9 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         'winningSubjectLine' => 'string',
         'openRate' => 'string',
         'clickRate' => 'string',
-        'winningVersionRate' => 'string'
+        'winningVersionRate' => 'string',
+        'statistics' => '\SendinBlue\Client\Model\AbTestCampaignResultStatistics',
+        'clickedLinks' => '\SendinBlue\Client\Model\AbTestCampaignResultClickedLinks'
     ];
 
     /**
@@ -76,7 +78,9 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         'winningSubjectLine' => null,
         'openRate' => null,
         'clickRate' => null,
-        'winningVersionRate' => null
+        'winningVersionRate' => null,
+        'statistics' => null,
+        'clickedLinks' => null
     ];
 
     /**
@@ -111,7 +115,9 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         'winningSubjectLine' => 'winningSubjectLine',
         'openRate' => 'openRate',
         'clickRate' => 'clickRate',
-        'winningVersionRate' => 'winningVersionRate'
+        'winningVersionRate' => 'winningVersionRate',
+        'statistics' => 'statistics',
+        'clickedLinks' => 'clickedLinks'
     ];
 
     /**
@@ -125,7 +131,9 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         'winningSubjectLine' => 'setWinningSubjectLine',
         'openRate' => 'setOpenRate',
         'clickRate' => 'setClickRate',
-        'winningVersionRate' => 'setWinningVersionRate'
+        'winningVersionRate' => 'setWinningVersionRate',
+        'statistics' => 'setStatistics',
+        'clickedLinks' => 'setClickedLinks'
     ];
 
     /**
@@ -139,7 +147,9 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         'winningSubjectLine' => 'getWinningSubjectLine',
         'openRate' => 'getOpenRate',
         'clickRate' => 'getClickRate',
-        'winningVersionRate' => 'getWinningVersionRate'
+        'winningVersionRate' => 'getWinningVersionRate',
+        'statistics' => 'getStatistics',
+        'clickedLinks' => 'getClickedLinks'
     ];
 
     /**
@@ -244,6 +254,8 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         $this->container['openRate'] = isset($data['openRate']) ? $data['openRate'] : null;
         $this->container['clickRate'] = isset($data['clickRate']) ? $data['clickRate'] : null;
         $this->container['winningVersionRate'] = isset($data['winningVersionRate']) ? $data['winningVersionRate'] : null;
+        $this->container['statistics'] = isset($data['statistics']) ? $data['statistics'] : null;
+        $this->container['clickedLinks'] = isset($data['clickedLinks']) ? $data['clickedLinks'] : null;
     }
 
     /**
@@ -444,6 +456,54 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
     public function setWinningVersionRate($winningVersionRate)
     {
         $this->container['winningVersionRate'] = $winningVersionRate;
+
+        return $this;
+    }
+
+    /**
+     * Gets statistics
+     *
+     * @return \SendinBlue\Client\Model\AbTestCampaignResultStatistics
+     */
+    public function getStatistics()
+    {
+        return $this->container['statistics'];
+    }
+
+    /**
+     * Sets statistics
+     *
+     * @param \SendinBlue\Client\Model\AbTestCampaignResultStatistics $statistics statistics
+     *
+     * @return $this
+     */
+    public function setStatistics($statistics)
+    {
+        $this->container['statistics'] = $statistics;
+
+        return $this;
+    }
+
+    /**
+     * Gets clickedLinks
+     *
+     * @return \SendinBlue\Client\Model\AbTestCampaignResultClickedLinks
+     */
+    public function getClickedLinks()
+    {
+        return $this->container['clickedLinks'];
+    }
+
+    /**
+     * Sets clickedLinks
+     *
+     * @param \SendinBlue\Client\Model\AbTestCampaignResultClickedLinks $clickedLinks clickedLinks
+     *
+     * @return $this
+     */
+    public function setClickedLinks($clickedLinks)
+    {
+        $this->container['clickedLinks'] = $clickedLinks;
 
         return $this;
     }

--- a/lib/Model/AbTestCampaignResultClickedLinks.php
+++ b/lib/Model/AbTestCampaignResultClickedLinks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSender
+ * AbTestCampaignResultClickedLinks
  *
  * PHP version 5
  *
@@ -33,15 +33,14 @@ use \ArrayAccess;
 use \SendinBlue\Client\ObjectSerializer;
 
 /**
- * SendSmtpEmailSender Class Doc Comment
+ * AbTestCampaignResultClickedLinks Class Doc Comment
  *
  * @category Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSender implements ModelInterface, ArrayAccess
+class AbTestCampaignResultClickedLinks implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -50,7 +49,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       *
       * @var string
       */
-    protected static $swaggerModelName = 'sendSmtpEmail_sender';
+    protected static $swaggerModelName = 'abTestCampaignResult_clickedLinks';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
@@ -58,9 +57,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'name' => 'string',
-        'email' => 'string',
-        'id' => 'int'
+        'versionA' => '\SendinBlue\Client\Model\AbTestVersionClicks',
+        'versionB' => '\SendinBlue\Client\Model\AbTestVersionClicks'
     ];
 
     /**
@@ -69,9 +67,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'name' => null,
-        'email' => 'email',
-        'id' => 'int64'
+        'versionA' => null,
+        'versionB' => null
     ];
 
     /**
@@ -101,9 +98,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name',
-        'email' => 'email',
-        'id' => 'id'
+        'versionA' => 'Version A',
+        'versionB' => 'Version B'
     ];
 
     /**
@@ -112,9 +108,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName',
-        'email' => 'setEmail',
-        'id' => 'setId'
+        'versionA' => 'setVersionA',
+        'versionB' => 'setVersionB'
     ];
 
     /**
@@ -123,9 +118,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName',
-        'email' => 'getEmail',
-        'id' => 'getId'
+        'versionA' => 'getVersionA',
+        'versionB' => 'getVersionB'
     ];
 
     /**
@@ -188,9 +182,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
+        $this->container['versionA'] = isset($data['versionA']) ? $data['versionA'] : null;
+        $this->container['versionB'] = isset($data['versionB']) ? $data['versionB'] : null;
     }
 
     /**
@@ -202,8 +195,11 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['email'] === null) {
-            $invalidProperties[] = "'email' can't be null";
+        if ($this->container['versionA'] === null) {
+            $invalidProperties[] = "'versionA' can't be null";
+        }
+        if ($this->container['versionB'] === null) {
+            $invalidProperties[] = "'versionB' can't be null";
         }
         return $invalidProperties;
     }
@@ -221,73 +217,49 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
 
 
     /**
-     * Gets name
+     * Gets versionA
      *
-     * @return string
+     * @return \SendinBlue\Client\Model\AbTestVersionClicks
      */
-    public function getName()
+    public function getVersionA()
     {
-        return $this->container['name'];
+        return $this->container['versionA'];
     }
 
     /**
-     * Sets name
+     * Sets versionA
      *
-     * @param string $name Name of the sender from which the emails will be sent. Maximum allowed characters are 70.
+     * @param \SendinBlue\Client\Model\AbTestVersionClicks $versionA versionA
      *
      * @return $this
      */
-    public function setName($name)
+    public function setVersionA($versionA)
     {
-        $this->container['name'] = $name;
+        $this->container['versionA'] = $versionA;
 
         return $this;
     }
 
     /**
-     * Gets email
+     * Gets versionB
      *
-     * @return string
+     * @return \SendinBlue\Client\Model\AbTestVersionClicks
      */
-    public function getEmail()
+    public function getVersionB()
     {
-        return $this->container['email'];
+        return $this->container['versionB'];
     }
 
     /**
-     * Sets email
+     * Sets versionB
      *
-     * @param string $email Email of the sender from which the emails will be sent
+     * @param \SendinBlue\Client\Model\AbTestVersionClicks $versionB versionB
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setVersionB($versionB)
     {
-        $this->container['email'] = $email;
-
-        return $this;
-    }
-
-    /**
-     * Gets id
-     *
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->container['id'];
-    }
-
-    /**
-     * Sets id
-     *
-     * @param int $id Id of the sender from which the emails will be sent
-     *
-     * @return $this
-     */
-    public function setId($id)
-    {
-        $this->container['id'] = $id;
+        $this->container['versionB'] = $versionB;
 
         return $this;
     }

--- a/lib/Model/AbTestCampaignResultStatistics.php
+++ b/lib/Model/AbTestCampaignResultStatistics.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSender
+ * AbTestCampaignResultStatistics
  *
  * PHP version 5
  *
@@ -33,15 +33,14 @@ use \ArrayAccess;
 use \SendinBlue\Client\ObjectSerializer;
 
 /**
- * SendSmtpEmailSender Class Doc Comment
+ * AbTestCampaignResultStatistics Class Doc Comment
  *
  * @category Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSender implements ModelInterface, ArrayAccess
+class AbTestCampaignResultStatistics implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -50,7 +49,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       *
       * @var string
       */
-    protected static $swaggerModelName = 'sendSmtpEmail_sender';
+    protected static $swaggerModelName = 'abTestCampaignResult_statistics';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
@@ -58,9 +57,12 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'name' => 'string',
-        'email' => 'string',
-        'id' => 'int'
+        'openers' => '\SendinBlue\Client\Model\AbTestVersionStats',
+        'clicks' => '\SendinBlue\Client\Model\AbTestVersionStats',
+        'unsubscribed' => '\SendinBlue\Client\Model\AbTestVersionStats',
+        'hardBounces' => '\SendinBlue\Client\Model\AbTestVersionStats',
+        'softBounces' => '\SendinBlue\Client\Model\AbTestVersionStats',
+        'complaints' => '\SendinBlue\Client\Model\AbTestVersionStats'
     ];
 
     /**
@@ -69,9 +71,12 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'name' => null,
-        'email' => 'email',
-        'id' => 'int64'
+        'openers' => null,
+        'clicks' => null,
+        'unsubscribed' => null,
+        'hardBounces' => null,
+        'softBounces' => null,
+        'complaints' => null
     ];
 
     /**
@@ -101,9 +106,12 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name',
-        'email' => 'email',
-        'id' => 'id'
+        'openers' => 'openers',
+        'clicks' => 'clicks',
+        'unsubscribed' => 'unsubscribed',
+        'hardBounces' => 'hardBounces',
+        'softBounces' => 'softBounces',
+        'complaints' => 'complaints'
     ];
 
     /**
@@ -112,9 +120,12 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName',
-        'email' => 'setEmail',
-        'id' => 'setId'
+        'openers' => 'setOpeners',
+        'clicks' => 'setClicks',
+        'unsubscribed' => 'setUnsubscribed',
+        'hardBounces' => 'setHardBounces',
+        'softBounces' => 'setSoftBounces',
+        'complaints' => 'setComplaints'
     ];
 
     /**
@@ -123,9 +134,12 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName',
-        'email' => 'getEmail',
-        'id' => 'getId'
+        'openers' => 'getOpeners',
+        'clicks' => 'getClicks',
+        'unsubscribed' => 'getUnsubscribed',
+        'hardBounces' => 'getHardBounces',
+        'softBounces' => 'getSoftBounces',
+        'complaints' => 'getComplaints'
     ];
 
     /**
@@ -188,9 +202,12 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
+        $this->container['openers'] = isset($data['openers']) ? $data['openers'] : null;
+        $this->container['clicks'] = isset($data['clicks']) ? $data['clicks'] : null;
+        $this->container['unsubscribed'] = isset($data['unsubscribed']) ? $data['unsubscribed'] : null;
+        $this->container['hardBounces'] = isset($data['hardBounces']) ? $data['hardBounces'] : null;
+        $this->container['softBounces'] = isset($data['softBounces']) ? $data['softBounces'] : null;
+        $this->container['complaints'] = isset($data['complaints']) ? $data['complaints'] : null;
     }
 
     /**
@@ -202,8 +219,23 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['email'] === null) {
-            $invalidProperties[] = "'email' can't be null";
+        if ($this->container['openers'] === null) {
+            $invalidProperties[] = "'openers' can't be null";
+        }
+        if ($this->container['clicks'] === null) {
+            $invalidProperties[] = "'clicks' can't be null";
+        }
+        if ($this->container['unsubscribed'] === null) {
+            $invalidProperties[] = "'unsubscribed' can't be null";
+        }
+        if ($this->container['hardBounces'] === null) {
+            $invalidProperties[] = "'hardBounces' can't be null";
+        }
+        if ($this->container['softBounces'] === null) {
+            $invalidProperties[] = "'softBounces' can't be null";
+        }
+        if ($this->container['complaints'] === null) {
+            $invalidProperties[] = "'complaints' can't be null";
         }
         return $invalidProperties;
     }
@@ -221,73 +253,145 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
 
 
     /**
-     * Gets name
+     * Gets openers
      *
-     * @return string
+     * @return \SendinBlue\Client\Model\AbTestVersionStats
      */
-    public function getName()
+    public function getOpeners()
     {
-        return $this->container['name'];
+        return $this->container['openers'];
     }
 
     /**
-     * Sets name
+     * Sets openers
      *
-     * @param string $name Name of the sender from which the emails will be sent. Maximum allowed characters are 70.
+     * @param \SendinBlue\Client\Model\AbTestVersionStats $openers openers
      *
      * @return $this
      */
-    public function setName($name)
+    public function setOpeners($openers)
     {
-        $this->container['name'] = $name;
+        $this->container['openers'] = $openers;
 
         return $this;
     }
 
     /**
-     * Gets email
+     * Gets clicks
      *
-     * @return string
+     * @return \SendinBlue\Client\Model\AbTestVersionStats
      */
-    public function getEmail()
+    public function getClicks()
     {
-        return $this->container['email'];
+        return $this->container['clicks'];
     }
 
     /**
-     * Sets email
+     * Sets clicks
      *
-     * @param string $email Email of the sender from which the emails will be sent
+     * @param \SendinBlue\Client\Model\AbTestVersionStats $clicks clicks
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setClicks($clicks)
     {
-        $this->container['email'] = $email;
+        $this->container['clicks'] = $clicks;
 
         return $this;
     }
 
     /**
-     * Gets id
+     * Gets unsubscribed
      *
-     * @return int
+     * @return \SendinBlue\Client\Model\AbTestVersionStats
      */
-    public function getId()
+    public function getUnsubscribed()
     {
-        return $this->container['id'];
+        return $this->container['unsubscribed'];
     }
 
     /**
-     * Sets id
+     * Sets unsubscribed
      *
-     * @param int $id Id of the sender from which the emails will be sent
+     * @param \SendinBlue\Client\Model\AbTestVersionStats $unsubscribed unsubscribed
      *
      * @return $this
      */
-    public function setId($id)
+    public function setUnsubscribed($unsubscribed)
     {
-        $this->container['id'] = $id;
+        $this->container['unsubscribed'] = $unsubscribed;
+
+        return $this;
+    }
+
+    /**
+     * Gets hardBounces
+     *
+     * @return \SendinBlue\Client\Model\AbTestVersionStats
+     */
+    public function getHardBounces()
+    {
+        return $this->container['hardBounces'];
+    }
+
+    /**
+     * Sets hardBounces
+     *
+     * @param \SendinBlue\Client\Model\AbTestVersionStats $hardBounces hardBounces
+     *
+     * @return $this
+     */
+    public function setHardBounces($hardBounces)
+    {
+        $this->container['hardBounces'] = $hardBounces;
+
+        return $this;
+    }
+
+    /**
+     * Gets softBounces
+     *
+     * @return \SendinBlue\Client\Model\AbTestVersionStats
+     */
+    public function getSoftBounces()
+    {
+        return $this->container['softBounces'];
+    }
+
+    /**
+     * Sets softBounces
+     *
+     * @param \SendinBlue\Client\Model\AbTestVersionStats $softBounces softBounces
+     *
+     * @return $this
+     */
+    public function setSoftBounces($softBounces)
+    {
+        $this->container['softBounces'] = $softBounces;
+
+        return $this;
+    }
+
+    /**
+     * Gets complaints
+     *
+     * @return \SendinBlue\Client\Model\AbTestVersionStats
+     */
+    public function getComplaints()
+    {
+        return $this->container['complaints'];
+    }
+
+    /**
+     * Sets complaints
+     *
+     * @param \SendinBlue\Client\Model\AbTestVersionStats $complaints complaints
+     *
+     * @return $this
+     */
+    public function setComplaints($complaints)
+    {
+        $this->container['complaints'] = $complaints;
 
         return $this;
     }

--- a/lib/Model/AbTestVersionClicks.php
+++ b/lib/Model/AbTestVersionClicks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSender
+ * AbTestVersionClicks
  *
  * PHP version 5
  *
@@ -33,15 +33,15 @@ use \ArrayAccess;
 use \SendinBlue\Client\ObjectSerializer;
 
 /**
- * SendSmtpEmailSender Class Doc Comment
+ * AbTestVersionClicks Class Doc Comment
  *
  * @category Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description Information on clicked links for a particular version
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSender implements ModelInterface, ArrayAccess
+class AbTestVersionClicks implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -50,7 +50,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       *
       * @var string
       */
-    protected static $swaggerModelName = 'sendSmtpEmail_sender';
+    protected static $swaggerModelName = 'abTestVersionClicks';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
@@ -58,9 +58,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'name' => 'string',
-        'email' => 'string',
-        'id' => 'int'
+        
     ];
 
     /**
@@ -69,9 +67,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'name' => null,
-        'email' => 'email',
-        'id' => 'int64'
+        
     ];
 
     /**
@@ -101,9 +97,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name',
-        'email' => 'email',
-        'id' => 'id'
+        
     ];
 
     /**
@@ -112,9 +106,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName',
-        'email' => 'setEmail',
-        'id' => 'setId'
+        
     ];
 
     /**
@@ -123,9 +115,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName',
-        'email' => 'getEmail',
-        'id' => 'getId'
+        
     ];
 
     /**
@@ -188,9 +178,6 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
 
     /**
@@ -200,11 +187,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = [];
+        $invalidProperties = parent::listInvalidProperties();
 
-        if ($this->container['email'] === null) {
-            $invalidProperties[] = "'email' can't be null";
-        }
         return $invalidProperties;
     }
 
@@ -219,78 +203,6 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
         return count($this->listInvalidProperties()) === 0;
     }
 
-
-    /**
-     * Gets name
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->container['name'];
-    }
-
-    /**
-     * Sets name
-     *
-     * @param string $name Name of the sender from which the emails will be sent. Maximum allowed characters are 70.
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        $this->container['name'] = $name;
-
-        return $this;
-    }
-
-    /**
-     * Gets email
-     *
-     * @return string
-     */
-    public function getEmail()
-    {
-        return $this->container['email'];
-    }
-
-    /**
-     * Sets email
-     *
-     * @param string $email Email of the sender from which the emails will be sent
-     *
-     * @return $this
-     */
-    public function setEmail($email)
-    {
-        $this->container['email'] = $email;
-
-        return $this;
-    }
-
-    /**
-     * Gets id
-     *
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->container['id'];
-    }
-
-    /**
-     * Sets id
-     *
-     * @param int $id Id of the sender from which the emails will be sent
-     *
-     * @return $this
-     */
-    public function setId($id)
-    {
-        $this->container['id'] = $id;
-
-        return $this;
-    }
     /**
      * Returns true if offset exists. False otherwise.
      *

--- a/lib/Model/AbTestVersionClicksInner.php
+++ b/lib/Model/AbTestVersionClicksInner.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSender
+ * AbTestVersionClicksInner
  *
  * PHP version 5
  *
@@ -33,15 +33,14 @@ use \ArrayAccess;
 use \SendinBlue\Client\ObjectSerializer;
 
 /**
- * SendSmtpEmailSender Class Doc Comment
+ * AbTestVersionClicksInner Class Doc Comment
  *
  * @category Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSender implements ModelInterface, ArrayAccess
+class AbTestVersionClicksInner implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -50,7 +49,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       *
       * @var string
       */
-    protected static $swaggerModelName = 'sendSmtpEmail_sender';
+    protected static $swaggerModelName = 'abTestVersionClicks_inner';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
@@ -58,9 +57,9 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'name' => 'string',
-        'email' => 'string',
-        'id' => 'int'
+        'link' => 'string',
+        'clicksCount' => 'float',
+        'clickRate' => 'string'
     ];
 
     /**
@@ -69,9 +68,9 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'name' => null,
-        'email' => 'email',
-        'id' => 'int64'
+        'link' => null,
+        'clicksCount' => 'int64',
+        'clickRate' => null
     ];
 
     /**
@@ -101,9 +100,9 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name',
-        'email' => 'email',
-        'id' => 'id'
+        'link' => 'link',
+        'clicksCount' => 'clicksCount',
+        'clickRate' => 'clickRate'
     ];
 
     /**
@@ -112,9 +111,9 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName',
-        'email' => 'setEmail',
-        'id' => 'setId'
+        'link' => 'setLink',
+        'clicksCount' => 'setClicksCount',
+        'clickRate' => 'setClickRate'
     ];
 
     /**
@@ -123,9 +122,9 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName',
-        'email' => 'getEmail',
-        'id' => 'getId'
+        'link' => 'getLink',
+        'clicksCount' => 'getClicksCount',
+        'clickRate' => 'getClickRate'
     ];
 
     /**
@@ -188,9 +187,9 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
+        $this->container['link'] = isset($data['link']) ? $data['link'] : null;
+        $this->container['clicksCount'] = isset($data['clicksCount']) ? $data['clicksCount'] : null;
+        $this->container['clickRate'] = isset($data['clickRate']) ? $data['clickRate'] : null;
     }
 
     /**
@@ -202,8 +201,14 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['email'] === null) {
-            $invalidProperties[] = "'email' can't be null";
+        if ($this->container['link'] === null) {
+            $invalidProperties[] = "'link' can't be null";
+        }
+        if ($this->container['clicksCount'] === null) {
+            $invalidProperties[] = "'clicksCount' can't be null";
+        }
+        if ($this->container['clickRate'] === null) {
+            $invalidProperties[] = "'clickRate' can't be null";
         }
         return $invalidProperties;
     }
@@ -221,73 +226,73 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
 
 
     /**
-     * Gets name
+     * Gets link
      *
      * @return string
      */
-    public function getName()
+    public function getLink()
     {
-        return $this->container['name'];
+        return $this->container['link'];
     }
 
     /**
-     * Sets name
+     * Sets link
      *
-     * @param string $name Name of the sender from which the emails will be sent. Maximum allowed characters are 70.
+     * @param string $link URL of the link
      *
      * @return $this
      */
-    public function setName($name)
+    public function setLink($link)
     {
-        $this->container['name'] = $name;
+        $this->container['link'] = $link;
 
         return $this;
     }
 
     /**
-     * Gets email
+     * Gets clicksCount
      *
-     * @return string
+     * @return float
      */
-    public function getEmail()
+    public function getClicksCount()
     {
-        return $this->container['email'];
+        return $this->container['clicksCount'];
     }
 
     /**
-     * Sets email
+     * Sets clicksCount
      *
-     * @param string $email Email of the sender from which the emails will be sent
+     * @param float $clicksCount Number of times a link is clicked
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setClicksCount($clicksCount)
     {
-        $this->container['email'] = $email;
+        $this->container['clicksCount'] = $clicksCount;
 
         return $this;
     }
 
     /**
-     * Gets id
+     * Gets clickRate
      *
-     * @return int
+     * @return string
      */
-    public function getId()
+    public function getClickRate()
     {
-        return $this->container['id'];
+        return $this->container['clickRate'];
     }
 
     /**
-     * Sets id
+     * Sets clickRate
      *
-     * @param int $id Id of the sender from which the emails will be sent
+     * @param string $clickRate Percentage of clicks of link with respect to total clicks
      *
      * @return $this
      */
-    public function setId($id)
+    public function setClickRate($clickRate)
     {
-        $this->container['id'] = $id;
+        $this->container['clickRate'] = $clickRate;
 
         return $this;
     }

--- a/lib/Model/AbTestVersionStats.php
+++ b/lib/Model/AbTestVersionStats.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSender
+ * AbTestVersionStats
  *
  * PHP version 5
  *
@@ -33,15 +33,15 @@ use \ArrayAccess;
 use \SendinBlue\Client\ObjectSerializer;
 
 /**
- * SendSmtpEmailSender Class Doc Comment
+ * AbTestVersionStats Class Doc Comment
  *
  * @category Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description Percentage of a particular event for both versions
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSender implements ModelInterface, ArrayAccess
+class AbTestVersionStats implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 
@@ -50,7 +50,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       *
       * @var string
       */
-    protected static $swaggerModelName = 'sendSmtpEmail_sender';
+    protected static $swaggerModelName = 'abTestVersionStats';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
@@ -58,9 +58,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'name' => 'string',
-        'email' => 'string',
-        'id' => 'int'
+        'versionA' => 'string',
+        'versionB' => 'string'
     ];
 
     /**
@@ -69,9 +68,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'name' => null,
-        'email' => 'email',
-        'id' => 'int64'
+        'versionA' => null,
+        'versionB' => null
     ];
 
     /**
@@ -101,9 +99,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'name' => 'name',
-        'email' => 'email',
-        'id' => 'id'
+        'versionA' => 'Version A',
+        'versionB' => 'Version B'
     ];
 
     /**
@@ -112,9 +109,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'name' => 'setName',
-        'email' => 'setEmail',
-        'id' => 'setId'
+        'versionA' => 'setVersionA',
+        'versionB' => 'setVersionB'
     ];
 
     /**
@@ -123,9 +119,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'name' => 'getName',
-        'email' => 'getEmail',
-        'id' => 'getId'
+        'versionA' => 'getVersionA',
+        'versionB' => 'getVersionB'
     ];
 
     /**
@@ -188,9 +183,8 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = isset($data['name']) ? $data['name'] : null;
-        $this->container['email'] = isset($data['email']) ? $data['email'] : null;
-        $this->container['id'] = isset($data['id']) ? $data['id'] : null;
+        $this->container['versionA'] = isset($data['versionA']) ? $data['versionA'] : null;
+        $this->container['versionB'] = isset($data['versionB']) ? $data['versionB'] : null;
     }
 
     /**
@@ -202,8 +196,11 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['email'] === null) {
-            $invalidProperties[] = "'email' can't be null";
+        if ($this->container['versionA'] === null) {
+            $invalidProperties[] = "'versionA' can't be null";
+        }
+        if ($this->container['versionB'] === null) {
+            $invalidProperties[] = "'versionB' can't be null";
         }
         return $invalidProperties;
     }
@@ -221,73 +218,49 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
 
 
     /**
-     * Gets name
+     * Gets versionA
      *
      * @return string
      */
-    public function getName()
+    public function getVersionA()
     {
-        return $this->container['name'];
+        return $this->container['versionA'];
     }
 
     /**
-     * Sets name
+     * Sets versionA
      *
-     * @param string $name Name of the sender from which the emails will be sent. Maximum allowed characters are 70.
+     * @param string $versionA percentage of an event for version A
      *
      * @return $this
      */
-    public function setName($name)
+    public function setVersionA($versionA)
     {
-        $this->container['name'] = $name;
+        $this->container['versionA'] = $versionA;
 
         return $this;
     }
 
     /**
-     * Gets email
+     * Gets versionB
      *
      * @return string
      */
-    public function getEmail()
+    public function getVersionB()
     {
-        return $this->container['email'];
+        return $this->container['versionB'];
     }
 
     /**
-     * Sets email
+     * Sets versionB
      *
-     * @param string $email Email of the sender from which the emails will be sent
+     * @param string $versionB percentage of an event for version B
      *
      * @return $this
      */
-    public function setEmail($email)
+    public function setVersionB($versionB)
     {
-        $this->container['email'] = $email;
-
-        return $this;
-    }
-
-    /**
-     * Gets id
-     *
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->container['id'];
-    }
-
-    /**
-     * Sets id
-     *
-     * @param int $id Id of the sender from which the emails will be sent
-     *
-     * @return $this
-     */
-    public function setId($id)
-    {
-        $this->container['id'] = $id;
+        $this->container['versionB'] = $versionB;
 
         return $this;
     }

--- a/lib/Model/AddContactToList.php
+++ b/lib/Model/AddContactToList.php
@@ -57,7 +57,8 @@ class AddContactToList implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerTypes = [
-        'emails' => 'string[]'
+        'emails' => 'string[]',
+        'ids' => 'int[]'
     ];
 
     /**
@@ -66,7 +67,8 @@ class AddContactToList implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'emails' => 'email'
+        'emails' => 'email',
+        'ids' => 'int64'
     ];
 
     /**
@@ -96,7 +98,8 @@ class AddContactToList implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $attributeMap = [
-        'emails' => 'emails'
+        'emails' => 'emails',
+        'ids' => 'ids'
     ];
 
     /**
@@ -105,7 +108,8 @@ class AddContactToList implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $setters = [
-        'emails' => 'setEmails'
+        'emails' => 'setEmails',
+        'ids' => 'setIds'
     ];
 
     /**
@@ -114,7 +118,8 @@ class AddContactToList implements ModelInterface, ArrayAccess
      * @var string[]
      */
     protected static $getters = [
-        'emails' => 'getEmails'
+        'emails' => 'getEmails',
+        'ids' => 'getIds'
     ];
 
     /**
@@ -178,6 +183,7 @@ class AddContactToList implements ModelInterface, ArrayAccess
     public function __construct(array $data = null)
     {
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
+        $this->container['ids'] = isset($data['ids']) ? $data['ids'] : null;
     }
 
     /**
@@ -217,13 +223,37 @@ class AddContactToList implements ModelInterface, ArrayAccess
     /**
      * Sets emails
      *
-     * @param string[] $emails Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+     * @param string[] $emails Mandatory if IDs are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
      *
      * @return $this
      */
     public function setEmails($emails)
     {
         $this->container['emails'] = $emails;
+
+        return $this;
+    }
+
+    /**
+     * Gets ids
+     *
+     * @return int[]
+     */
+    public function getIds()
+    {
+        return $this->container['ids'];
+    }
+
+    /**
+     * Sets ids
+     *
+     * @param int[] $ids Mandatory if Emails are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+     *
+     * @return $this
+     */
+    public function setIds($ids)
+    {
+        $this->container['ids'] = $ids;
 
         return $this;
     }

--- a/lib/Model/CreateDoiContact.php
+++ b/lib/Model/CreateDoiContact.php
@@ -228,6 +228,9 @@ class CreateDoiContact implements ModelInterface, ArrayAccess
         if ($this->container['templateId'] === null) {
             $invalidProperties[] = "'templateId' can't be null";
         }
+        if ($this->container['redirectionUrl'] === null) {
+            $invalidProperties[] = "'redirectionUrl' can't be null";
+        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetAggregatedReport.php
+++ b/lib/Model/GetAggregatedReport.php
@@ -261,45 +261,6 @@ class GetAggregatedReport implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['range'] === null) {
-            $invalidProperties[] = "'range' can't be null";
-        }
-        if ($this->container['requests'] === null) {
-            $invalidProperties[] = "'requests' can't be null";
-        }
-        if ($this->container['delivered'] === null) {
-            $invalidProperties[] = "'delivered' can't be null";
-        }
-        if ($this->container['hardBounces'] === null) {
-            $invalidProperties[] = "'hardBounces' can't be null";
-        }
-        if ($this->container['softBounces'] === null) {
-            $invalidProperties[] = "'softBounces' can't be null";
-        }
-        if ($this->container['clicks'] === null) {
-            $invalidProperties[] = "'clicks' can't be null";
-        }
-        if ($this->container['uniqueClicks'] === null) {
-            $invalidProperties[] = "'uniqueClicks' can't be null";
-        }
-        if ($this->container['opens'] === null) {
-            $invalidProperties[] = "'opens' can't be null";
-        }
-        if ($this->container['uniqueOpens'] === null) {
-            $invalidProperties[] = "'uniqueOpens' can't be null";
-        }
-        if ($this->container['spamReports'] === null) {
-            $invalidProperties[] = "'spamReports' can't be null";
-        }
-        if ($this->container['blocked'] === null) {
-            $invalidProperties[] = "'blocked' can't be null";
-        }
-        if ($this->container['invalid'] === null) {
-            $invalidProperties[] = "'invalid' can't be null";
-        }
-        if ($this->container['unsubscribed'] === null) {
-            $invalidProperties[] = "'unsubscribed' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetCampaignStats.php
+++ b/lib/Model/GetCampaignStats.php
@@ -68,7 +68,8 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
         'uniqueViews' => 'int',
         'unsubscriptions' => 'int',
         'viewed' => 'int',
-        'deferred' => 'int'
+        'deferred' => 'int',
+        'returnBounce' => 'int'
     ];
 
     /**
@@ -88,7 +89,8 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
         'uniqueViews' => 'int64',
         'unsubscriptions' => 'int64',
         'viewed' => 'int64',
-        'deferred' => 'int64'
+        'deferred' => 'int64',
+        'returnBounce' => 'int64'
     ];
 
     /**
@@ -129,7 +131,8 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
         'uniqueViews' => 'uniqueViews',
         'unsubscriptions' => 'unsubscriptions',
         'viewed' => 'viewed',
-        'deferred' => 'deferred'
+        'deferred' => 'deferred',
+        'returnBounce' => 'returnBounce'
     ];
 
     /**
@@ -149,7 +152,8 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
         'uniqueViews' => 'setUniqueViews',
         'unsubscriptions' => 'setUnsubscriptions',
         'viewed' => 'setViewed',
-        'deferred' => 'setDeferred'
+        'deferred' => 'setDeferred',
+        'returnBounce' => 'setReturnBounce'
     ];
 
     /**
@@ -169,7 +173,8 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
         'uniqueViews' => 'getUniqueViews',
         'unsubscriptions' => 'getUnsubscriptions',
         'viewed' => 'getViewed',
-        'deferred' => 'getDeferred'
+        'deferred' => 'getDeferred',
+        'returnBounce' => 'getReturnBounce'
     ];
 
     /**
@@ -244,6 +249,7 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
         $this->container['unsubscriptions'] = isset($data['unsubscriptions']) ? $data['unsubscriptions'] : null;
         $this->container['viewed'] = isset($data['viewed']) ? $data['viewed'] : null;
         $this->container['deferred'] = isset($data['deferred']) ? $data['deferred'] : null;
+        $this->container['returnBounce'] = isset($data['returnBounce']) ? $data['returnBounce'] : null;
     }
 
     /**
@@ -584,6 +590,30 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
     public function setDeferred($deferred)
     {
         $this->container['deferred'] = $deferred;
+
+        return $this;
+    }
+
+    /**
+     * Gets returnBounce
+     *
+     * @return int
+     */
+    public function getReturnBounce()
+    {
+        return $this->container['returnBounce'];
+    }
+
+    /**
+     * Sets returnBounce
+     *
+     * @param int $returnBounce Total number of non-delivered campaigns for a particular campaign id.
+     *
+     * @return $this
+     */
+    public function setReturnBounce($returnBounce)
+    {
+        $this->container['returnBounce'] = $returnBounce;
 
         return $this;
     }

--- a/lib/Model/RemoveContactFromList.php
+++ b/lib/Model/RemoveContactFromList.php
@@ -58,6 +58,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'emails' => 'string[]',
+        'ids' => 'int[]',
         'all' => 'bool'
     ];
 
@@ -67,7 +68,8 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
       * @var string[]
       */
     protected static $swaggerFormats = [
-        'emails' => 'email',
+        'emails' => null,
+        'ids' => 'int64',
         'all' => null
     ];
 
@@ -99,6 +101,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'emails' => 'emails',
+        'ids' => 'ids',
         'all' => 'all'
     ];
 
@@ -109,6 +112,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'emails' => 'setEmails',
+        'ids' => 'setIds',
         'all' => 'setAll'
     ];
 
@@ -119,6 +123,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'emails' => 'getEmails',
+        'ids' => 'getIds',
         'all' => 'getAll'
     ];
 
@@ -183,6 +188,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
     public function __construct(array $data = null)
     {
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
+        $this->container['ids'] = isset($data['ids']) ? $data['ids'] : null;
         $this->container['all'] = isset($data['all']) ? $data['all'] : null;
     }
 
@@ -235,6 +241,30 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
     }
 
     /**
+     * Gets ids
+     *
+     * @return int[]
+     */
+    public function getIds()
+    {
+        return $this->container['ids'];
+    }
+
+    /**
+     * Sets ids
+     *
+     * @param int[] $ids Mandatory if Emails are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+     *
+     * @return $this
+     */
+    public function setIds($ids)
+    {
+        $this->container['ids'] = $ids;
+
+        return $this;
+    }
+
+    /**
      * Gets all
      *
      * @return bool
@@ -247,7 +277,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
     /**
      * Sets all
      *
-     * @param bool $all Required if 'emails' is empty. Remove all existing contacts from a list.  A process will be created in this scenario. You can fetch the process details to know about the progress
+     * @param bool $all Required if none of 'emails' or 'ids' are passed. Remove all existing contacts from a list.  A process will be created in this scenario. You can fetch the process details to know about the progress
      *
      * @return $this
      */

--- a/lib/Model/RequestSMSRecipientExport.php
+++ b/lib/Model/RequestSMSRecipientExport.php
@@ -40,7 +40,7 @@ use \SendinBlue\Client\ObjectSerializer;
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class RequestSMSRecipientExport implements ModelInterface, ArrayAccess
+class RequestSmsRecipientExport implements ModelInterface, ArrayAccess
 {
     const DISCRIMINATOR = null;
 

--- a/test/Api/TransactionalEmailsApiTest.php
+++ b/test/Api/TransactionalEmailsApiTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SMTPApiTest
+ * TransactionalEmailsApiTest
  * PHP version 5
  *
  * @category Class
@@ -33,14 +33,14 @@ use \SendinBlue\Client\ApiException;
 use \SendinBlue\Client\ObjectSerializer;
 
 /**
- * SMTPApiTest Class Doc Comment
+ * TransactionalEmailsApiTest Class Doc Comment
  *
  * @category Class
  * @package  SendinBlue\Client
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
-class SMTPApiTest extends \PHPUnit_Framework_TestCase
+class TransactionalEmailsApiTest extends \PHPUnit_Framework_TestCase
 {
 
     /**

--- a/test/Model/AbTestCampaignResultClickedLinksTest.php
+++ b/test/Model/AbTestCampaignResultClickedLinksTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSenderTest
+ * AbTestCampaignResultClickedLinksTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * SendSmtpEmailSenderTest Class Doc Comment
+ * AbTestCampaignResultClickedLinksTest Class Doc Comment
  *
  * @category    Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description AbTestCampaignResultClickedLinks
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
+class AbTestCampaignResultClickedLinksTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,30 +70,23 @@ class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "SendSmtpEmailSender"
+     * Test "AbTestCampaignResultClickedLinks"
      */
-    public function testSendSmtpEmailSender()
+    public function testAbTestCampaignResultClickedLinks()
     {
     }
 
     /**
-     * Test attribute "name"
+     * Test attribute "versionA"
      */
-    public function testPropertyName()
+    public function testPropertyVersionA()
     {
     }
 
     /**
-     * Test attribute "email"
+     * Test attribute "versionB"
      */
-    public function testPropertyEmail()
-    {
-    }
-
-    /**
-     * Test attribute "id"
-     */
-    public function testPropertyId()
+    public function testPropertyVersionB()
     {
     }
 }

--- a/test/Model/AbTestCampaignResultStatisticsTest.php
+++ b/test/Model/AbTestCampaignResultStatisticsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSenderTest
+ * AbTestCampaignResultStatisticsTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * SendSmtpEmailSenderTest Class Doc Comment
+ * AbTestCampaignResultStatisticsTest Class Doc Comment
  *
  * @category    Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description AbTestCampaignResultStatistics
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
+class AbTestCampaignResultStatisticsTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,30 +70,51 @@ class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "SendSmtpEmailSender"
+     * Test "AbTestCampaignResultStatistics"
      */
-    public function testSendSmtpEmailSender()
+    public function testAbTestCampaignResultStatistics()
     {
     }
 
     /**
-     * Test attribute "name"
+     * Test attribute "openers"
      */
-    public function testPropertyName()
+    public function testPropertyOpeners()
     {
     }
 
     /**
-     * Test attribute "email"
+     * Test attribute "clicks"
      */
-    public function testPropertyEmail()
+    public function testPropertyClicks()
     {
     }
 
     /**
-     * Test attribute "id"
+     * Test attribute "unsubscribed"
      */
-    public function testPropertyId()
+    public function testPropertyUnsubscribed()
+    {
+    }
+
+    /**
+     * Test attribute "hardBounces"
+     */
+    public function testPropertyHardBounces()
+    {
+    }
+
+    /**
+     * Test attribute "softBounces"
+     */
+    public function testPropertySoftBounces()
+    {
+    }
+
+    /**
+     * Test attribute "complaints"
+     */
+    public function testPropertyComplaints()
     {
     }
 }

--- a/test/Model/AbTestCampaignResultTest.php
+++ b/test/Model/AbTestCampaignResultTest.php
@@ -117,4 +117,18 @@ class AbTestCampaignResultTest extends \PHPUnit_Framework_TestCase
     public function testPropertyWinningVersionRate()
     {
     }
+
+    /**
+     * Test attribute "statistics"
+     */
+    public function testPropertyStatistics()
+    {
+    }
+
+    /**
+     * Test attribute "clickedLinks"
+     */
+    public function testPropertyClickedLinks()
+    {
+    }
 }

--- a/test/Model/AbTestVersionClicksInnerTest.php
+++ b/test/Model/AbTestVersionClicksInnerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSenderTest
+ * AbTestVersionClicksInnerTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * SendSmtpEmailSenderTest Class Doc Comment
+ * AbTestVersionClicksInnerTest Class Doc Comment
  *
  * @category    Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description AbTestVersionClicksInner
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
+class AbTestVersionClicksInnerTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,30 +70,30 @@ class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "SendSmtpEmailSender"
+     * Test "AbTestVersionClicksInner"
      */
-    public function testSendSmtpEmailSender()
+    public function testAbTestVersionClicksInner()
     {
     }
 
     /**
-     * Test attribute "name"
+     * Test attribute "link"
      */
-    public function testPropertyName()
+    public function testPropertyLink()
     {
     }
 
     /**
-     * Test attribute "email"
+     * Test attribute "clicksCount"
      */
-    public function testPropertyEmail()
+    public function testPropertyClicksCount()
     {
     }
 
     /**
-     * Test attribute "id"
+     * Test attribute "clickRate"
      */
-    public function testPropertyId()
+    public function testPropertyClickRate()
     {
     }
 }

--- a/test/Model/AbTestVersionClicksTest.php
+++ b/test/Model/AbTestVersionClicksTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSenderTest
+ * AbTestVersionClicksTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * SendSmtpEmailSenderTest Class Doc Comment
+ * AbTestVersionClicksTest Class Doc Comment
  *
  * @category    Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description Information on clicked links for a particular version
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
+class AbTestVersionClicksTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,30 +70,9 @@ class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "SendSmtpEmailSender"
+     * Test "AbTestVersionClicks"
      */
-    public function testSendSmtpEmailSender()
-    {
-    }
-
-    /**
-     * Test attribute "name"
-     */
-    public function testPropertyName()
-    {
-    }
-
-    /**
-     * Test attribute "email"
-     */
-    public function testPropertyEmail()
-    {
-    }
-
-    /**
-     * Test attribute "id"
-     */
-    public function testPropertyId()
+    public function testAbTestVersionClicks()
     {
     }
 }

--- a/test/Model/AbTestVersionStatsTest.php
+++ b/test/Model/AbTestVersionStatsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SendSmtpEmailSenderTest
+ * AbTestVersionStatsTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * SendSmtpEmailSenderTest Class Doc Comment
+ * AbTestVersionStatsTest Class Doc Comment
  *
  * @category    Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description Percentage of a particular event for both versions
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
+class AbTestVersionStatsTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,30 +70,23 @@ class SendSmtpEmailSenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "SendSmtpEmailSender"
+     * Test "AbTestVersionStats"
      */
-    public function testSendSmtpEmailSender()
+    public function testAbTestVersionStats()
     {
     }
 
     /**
-     * Test attribute "name"
+     * Test attribute "versionA"
      */
-    public function testPropertyName()
+    public function testPropertyVersionA()
     {
     }
 
     /**
-     * Test attribute "email"
+     * Test attribute "versionB"
      */
-    public function testPropertyEmail()
-    {
-    }
-
-    /**
-     * Test attribute "id"
-     */
-    public function testPropertyId()
+    public function testPropertyVersionB()
     {
     }
 }

--- a/test/Model/RemoveContactFromListTest.php
+++ b/test/Model/RemoveContactFromListTest.php
@@ -84,6 +84,13 @@ class RemoveContactFromListTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test attribute "ids"
+     */
+    public function testPropertyIds()
+    {
+    }
+
+    /**
      * Test attribute "all"
      */
     public function testPropertyAll()


### PR DESCRIPTION
- API instance SMTPApi renamed to TransactionalEmailsApi
- Fixed response for getEmailCampaigns in case of no email campaign
- RedirectionUrl is now mandatory for DOI
- Sent event now included in events array for transactional webhook
- Extended statistics for A/B test results
- Added sender id parameter in sendTransactionalEmail
- Added Contact Id as additional key for contact operations