### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/docs export-ignore
+/test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
We don't need these files in production.

Files and folders listed in `.gitattributes` will not be included when you require the package.