### PR TITLE
AP-1066 Updated version to 7.3.0 and added user-agent conditionally

### DIFF
--- a/docs/Api/ContactsApi.md
+++ b/docs/Api/ContactsApi.md
@@ -777,7 +777,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getContacts**
-> \SendinBlue\Client\Model\GetContacts getContacts($limit, $offset, $modifiedSince)
+> \SendinBlue\Client\Model\GetContacts getContacts($limit, $offset, $modifiedSince, $sort)
 
 Get all the contacts
 
@@ -804,9 +804,10 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
 $limit = 50; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
 $modifiedSince = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getContacts($limit, $offset, $modifiedSince);
+    $result = $apiInstance->getContacts($limit, $offset, $modifiedSince, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getContacts: ', $e->getMessage(), PHP_EOL;
@@ -821,6 +822,7 @@ Name | Type | Description  | Notes
  **limit** | **int**| Number of documents per page | [optional] [default to 50]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
  **modifiedSince** | **\DateTime**| Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -838,7 +840,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getContactsFromList**
-> \SendinBlue\Client\Model\GetContacts getContactsFromList($listId, $modifiedSince, $limit, $offset)
+> \SendinBlue\Client\Model\GetContacts getContactsFromList($listId, $modifiedSince, $limit, $offset, $sort)
 
 Get contacts in a list
 
@@ -866,9 +868,10 @@ $listId = 789; // int | Id of the list
 $modifiedSince = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
 $limit = 50; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getContactsFromList($listId, $modifiedSince, $limit, $offset);
+    $result = $apiInstance->getContactsFromList($listId, $modifiedSince, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getContactsFromList: ', $e->getMessage(), PHP_EOL;
@@ -884,6 +887,7 @@ Name | Type | Description  | Notes
  **modifiedSince** | **\DateTime**| Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. | [optional]
  **limit** | **int**| Number of documents per page | [optional] [default to 50]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -958,7 +962,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getFolderLists**
-> \SendinBlue\Client\Model\GetFolderLists getFolderLists($folderId, $limit, $offset)
+> \SendinBlue\Client\Model\GetFolderLists getFolderLists($folderId, $limit, $offset, $sort)
 
 Get lists in a folder
 
@@ -985,9 +989,10 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
 $folderId = 789; // int | Id of the folder
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getFolderLists($folderId, $limit, $offset);
+    $result = $apiInstance->getFolderLists($folderId, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getFolderLists: ', $e->getMessage(), PHP_EOL;
@@ -1002,6 +1007,7 @@ Name | Type | Description  | Notes
  **folderId** | **int**| Id of the folder |
  **limit** | **int**| Number of documents per page | [optional] [default to 10]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -1019,7 +1025,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getFolders**
-> \SendinBlue\Client\Model\GetFolders getFolders($limit, $offset)
+> \SendinBlue\Client\Model\GetFolders getFolders($limit, $offset, $sort)
 
 Get all folders
 
@@ -1045,9 +1051,10 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
 );
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getFolders($limit, $offset);
+    $result = $apiInstance->getFolders($limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getFolders: ', $e->getMessage(), PHP_EOL;
@@ -1061,6 +1068,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **limit** | **int**| Number of documents per page | [default to 10]
  **offset** | **int**| Index of the first document of the page | [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -1135,7 +1143,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getLists**
-> \SendinBlue\Client\Model\GetLists getLists($limit, $offset)
+> \SendinBlue\Client\Model\GetLists getLists($limit, $offset, $sort)
 
 Get all the lists
 
@@ -1161,9 +1169,10 @@ $apiInstance = new SendinBlue\Client\Api\ContactsApi(
 );
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getLists($limit, $offset);
+    $result = $apiInstance->getLists($limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ContactsApi->getLists: ', $e->getMessage(), PHP_EOL;
@@ -1177,6 +1186,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **limit** | **int**| Number of documents per page | [optional] [default to 10]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/EmailCampaignsApi.md
+++ b/docs/Api/EmailCampaignsApi.md
@@ -308,7 +308,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getEmailCampaigns**
-> \SendinBlue\Client\Model\GetEmailCampaigns getEmailCampaigns($type, $status, $startDate, $endDate, $limit, $offset)
+> \SendinBlue\Client\Model\GetEmailCampaigns getEmailCampaigns($type, $status, $startDate, $endDate, $limit, $offset, $sort)
 
 Return all your created email campaigns
 
@@ -338,9 +338,10 @@ $startDate = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Mandator
 $endDate = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
 $limit = 500; // int | Number of documents per page
 $offset = 0; // int | Index of the first document in the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getEmailCampaigns($type, $status, $startDate, $endDate, $limit, $offset);
+    $result = $apiInstance->getEmailCampaigns($type, $status, $startDate, $endDate, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling EmailCampaignsApi->getEmailCampaigns: ', $e->getMessage(), PHP_EOL;
@@ -358,6 +359,7 @@ Name | Type | Description  | Notes
  **endDate** | **\DateTime**| Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) | [optional]
  **limit** | **int**| Number of documents per page | [optional] [default to 500]
  **offset** | **int**| Index of the first document in the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/FoldersApi.md
+++ b/docs/Api/FoldersApi.md
@@ -183,7 +183,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getFolderLists**
-> \SendinBlue\Client\Model\GetFolderLists getFolderLists($folderId, $limit, $offset)
+> \SendinBlue\Client\Model\GetFolderLists getFolderLists($folderId, $limit, $offset, $sort)
 
 Get lists in a folder
 
@@ -210,9 +210,10 @@ $apiInstance = new SendinBlue\Client\Api\FoldersApi(
 $folderId = 789; // int | Id of the folder
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getFolderLists($folderId, $limit, $offset);
+    $result = $apiInstance->getFolderLists($folderId, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling FoldersApi->getFolderLists: ', $e->getMessage(), PHP_EOL;
@@ -227,6 +228,7 @@ Name | Type | Description  | Notes
  **folderId** | **int**| Id of the folder |
  **limit** | **int**| Number of documents per page | [optional] [default to 10]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -244,7 +246,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getFolders**
-> \SendinBlue\Client\Model\GetFolders getFolders($limit, $offset)
+> \SendinBlue\Client\Model\GetFolders getFolders($limit, $offset, $sort)
 
 Get all folders
 
@@ -270,9 +272,10 @@ $apiInstance = new SendinBlue\Client\Api\FoldersApi(
 );
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getFolders($limit, $offset);
+    $result = $apiInstance->getFolders($limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling FoldersApi->getFolders: ', $e->getMessage(), PHP_EOL;
@@ -286,6 +289,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **limit** | **int**| Number of documents per page | [default to 10]
  **offset** | **int**| Index of the first document of the page | [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/ListsApi.md
+++ b/docs/Api/ListsApi.md
@@ -188,7 +188,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getContactsFromList**
-> \SendinBlue\Client\Model\GetContacts getContactsFromList($listId, $modifiedSince, $limit, $offset)
+> \SendinBlue\Client\Model\GetContacts getContactsFromList($listId, $modifiedSince, $limit, $offset, $sort)
 
 Get contacts in a list
 
@@ -216,9 +216,10 @@ $listId = 789; // int | Id of the list
 $modifiedSince = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
 $limit = 50; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getContactsFromList($listId, $modifiedSince, $limit, $offset);
+    $result = $apiInstance->getContactsFromList($listId, $modifiedSince, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ListsApi->getContactsFromList: ', $e->getMessage(), PHP_EOL;
@@ -234,6 +235,7 @@ Name | Type | Description  | Notes
  **modifiedSince** | **\DateTime**| Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. | [optional]
  **limit** | **int**| Number of documents per page | [optional] [default to 50]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -251,7 +253,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getFolderLists**
-> \SendinBlue\Client\Model\GetFolderLists getFolderLists($folderId, $limit, $offset)
+> \SendinBlue\Client\Model\GetFolderLists getFolderLists($folderId, $limit, $offset, $sort)
 
 Get lists in a folder
 
@@ -278,9 +280,10 @@ $apiInstance = new SendinBlue\Client\Api\ListsApi(
 $folderId = 789; // int | Id of the folder
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getFolderLists($folderId, $limit, $offset);
+    $result = $apiInstance->getFolderLists($folderId, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ListsApi->getFolderLists: ', $e->getMessage(), PHP_EOL;
@@ -295,6 +298,7 @@ Name | Type | Description  | Notes
  **folderId** | **int**| Id of the folder |
  **limit** | **int**| Number of documents per page | [optional] [default to 10]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -369,7 +373,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getLists**
-> \SendinBlue\Client\Model\GetLists getLists($limit, $offset)
+> \SendinBlue\Client\Model\GetLists getLists($limit, $offset, $sort)
 
 Get all the lists
 
@@ -395,9 +399,10 @@ $apiInstance = new SendinBlue\Client\Api\ListsApi(
 );
 $limit = 10; // int | Number of documents per page
 $offset = 0; // int | Index of the first document of the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getLists($limit, $offset);
+    $result = $apiInstance->getLists($limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ListsApi->getLists: ', $e->getMessage(), PHP_EOL;
@@ -411,6 +416,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **limit** | **int**| Number of documents per page | [optional] [default to 10]
  **offset** | **int**| Index of the first document of the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/ProcessApi.md
+++ b/docs/Api/ProcessApi.md
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getProcesses**
-> \SendinBlue\Client\Model\GetProcesses getProcesses($limit, $offset)
+> \SendinBlue\Client\Model\GetProcesses getProcesses($limit, $offset, $sort)
 
 Return all the processes for your account
 
@@ -92,9 +92,10 @@ $apiInstance = new SendinBlue\Client\Api\ProcessApi(
 );
 $limit = 10; // int | Number limitation for the result returned
 $offset = 0; // int | Beginning point in the list to retrieve from.
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getProcesses($limit, $offset);
+    $result = $apiInstance->getProcesses($limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling ProcessApi->getProcesses: ', $e->getMessage(), PHP_EOL;
@@ -108,6 +109,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **limit** | **int**| Number limitation for the result returned | [optional] [default to 10]
  **offset** | **int**| Beginning point in the list to retrieve from. | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/SMSCampaignsApi.md
+++ b/docs/Api/SMSCampaignsApi.md
@@ -187,7 +187,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getSmsCampaigns**
-> \SendinBlue\Client\Model\GetSmsCampaigns getSmsCampaigns($status, $startDate, $endDate, $limit, $offset)
+> \SendinBlue\Client\Model\GetSmsCampaigns getSmsCampaigns($status, $startDate, $endDate, $limit, $offset, $sort)
 
 Returns the information for all your created SMS campaigns
 
@@ -216,9 +216,10 @@ $startDate = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Mandator
 $endDate = new \DateTime("2013-10-20T19:20:30+01:00"); // \DateTime | Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
 $limit = 500; // int | Number limitation for the result returned
 $offset = 0; // int | Beginning point in the list to retrieve from.
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getSmsCampaigns($status, $startDate, $endDate, $limit, $offset);
+    $result = $apiInstance->getSmsCampaigns($status, $startDate, $endDate, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling SMSCampaignsApi->getSmsCampaigns: ', $e->getMessage(), PHP_EOL;
@@ -235,6 +236,7 @@ Name | Type | Description  | Notes
  **endDate** | **\DateTime**| Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) | [optional]
  **limit** | **int**| Number limitation for the result returned | [optional] [default to 500]
  **offset** | **int**| Beginning point in the list to retrieve from. | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/TransactionalEmailsApi.md
+++ b/docs/Api/TransactionalEmailsApi.md
@@ -4,10 +4,13 @@ All URIs are relative to *https://api.sendinblue.com/v3*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**blockNewDomain**](TransactionalEmailsApi.md#blockNewDomain) | **POST** /smtp/blockedDomains | Add a new domain to the list of blocked domains
 [**createSmtpTemplate**](TransactionalEmailsApi.md#createSmtpTemplate) | **POST** /smtp/templates | Create an email template
+[**deleteBlockedDomain**](TransactionalEmailsApi.md#deleteBlockedDomain) | **DELETE** /smtp/blockedDomains/{domain} | Unblock an existing domain from the list of blocked domains
 [**deleteHardbounces**](TransactionalEmailsApi.md#deleteHardbounces) | **POST** /smtp/deleteHardbounces | Delete hardbounces
 [**deleteSmtpTemplate**](TransactionalEmailsApi.md#deleteSmtpTemplate) | **DELETE** /smtp/templates/{templateId} | Delete an inactive email template
 [**getAggregatedSmtpReport**](TransactionalEmailsApi.md#getAggregatedSmtpReport) | **GET** /smtp/statistics/aggregatedReport | Get your transactional email activity aggregated over a period of time
+[**getBlockedDomains**](TransactionalEmailsApi.md#getBlockedDomains) | **GET** /smtp/blockedDomains | Get the list of blocked domains
 [**getEmailEventReport**](TransactionalEmailsApi.md#getEmailEventReport) | **GET** /smtp/statistics/events | Get all your transactional email activity (unaggregated events)
 [**getSmtpReport**](TransactionalEmailsApi.md#getSmtpReport) | **GET** /smtp/statistics/reports | Get your transactional email activity aggregated per day
 [**getSmtpTemplate**](TransactionalEmailsApi.md#getSmtpTemplate) | **GET** /smtp/templates/{templateId} | Returns the template information
@@ -22,6 +25,64 @@ Method | HTTP request | Description
 [**smtpLogMessageIdDelete**](TransactionalEmailsApi.md#smtpLogMessageIdDelete) | **DELETE** /smtp/log/{messageId} | Delete an SMTP transactional log
 [**updateSmtpTemplate**](TransactionalEmailsApi.md#updateSmtpTemplate) | **PUT** /smtp/templates/{templateId} | Update an email template
 
+
+# **blockNewDomain**
+> blockNewDomain($blockDomain)
+
+Add a new domain to the list of blocked domains
+
+Blocks a new domain in order to avoid messages being sent to the same
+
+### Example
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: api-key
+$config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
+// Configure API key authorization: partner-key
+$config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('partner-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
+
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client(),
+    $config
+);
+$blockDomain = new \SendinBlue\Client\Model\BlockDomain(); // \SendinBlue\Client\Model\BlockDomain | 
+
+try {
+    $apiInstance->blockNewDomain($blockDomain);
+} catch (Exception $e) {
+    echo 'Exception when calling TransactionalEmailsApi->blockNewDomain: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **blockDomain** | [**\SendinBlue\Client\Model\BlockDomain**](../Model/BlockDomain.md)|  |
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[api-key](../../README.md#api-key), [partner-key](../../README.md#partner-key)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **createSmtpTemplate**
 > \SendinBlue\Client\Model\CreateModel createSmtpTemplate($smtpTemplate)
@@ -68,6 +129,64 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**\SendinBlue\Client\Model\CreateModel**](../Model/CreateModel.md)
+
+### Authorization
+
+[api-key](../../README.md#api-key), [partner-key](../../README.md#partner-key)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+# **deleteBlockedDomain**
+> deleteBlockedDomain($domain)
+
+Unblock an existing domain from the list of blocked domains
+
+Unblocks an existing domain from the list of blocked domains
+
+### Example
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: api-key
+$config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
+// Configure API key authorization: partner-key
+$config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('partner-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
+
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client(),
+    $config
+);
+$domain = "domain_example"; // string | The name of the domain to be deleted
+
+try {
+    $apiInstance->deleteBlockedDomain($domain);
+} catch (Exception $e) {
+    echo 'Exception when calling TransactionalEmailsApi->deleteBlockedDomain: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **domain** | **string**| The name of the domain to be deleted |
+
+### Return type
+
+void (empty response body)
 
 ### Authorization
 
@@ -257,8 +376,63 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
+# **getBlockedDomains**
+> \SendinBlue\Client\Model\GetBlockedDomains getBlockedDomains()
+
+Get the list of blocked domains
+
+Get the list of blocked domains
+
+### Example
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: api-key
+$config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('api-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api-key', 'Bearer');
+// Configure API key authorization: partner-key
+$config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKey('partner-key', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// $config = SendinBlue\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('partner-key', 'Bearer');
+
+$apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client(),
+    $config
+);
+
+try {
+    $result = $apiInstance->getBlockedDomains();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling TransactionalEmailsApi->getBlockedDomains: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**\SendinBlue\Client\Model\GetBlockedDomains**](../Model/GetBlockedDomains.md)
+
+### Authorization
+
+[api-key](../../README.md#api-key), [partner-key](../../README.md#partner-key)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
 # **getEmailEventReport**
-> \SendinBlue\Client\Model\GetEmailEventReport getEmailEventReport($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId)
+> \SendinBlue\Client\Model\GetEmailEventReport getEmailEventReport($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId, $sort)
 
 Get all your transactional email activity (unaggregated events)
 
@@ -292,9 +466,10 @@ $event = "event_example"; // string | Filter the report for a specific event typ
 $tags = "tags_example"; // string | Filter the report for tags (serialized and urlencoded array)
 $messageId = "messageId_example"; // string | Filter on a specific message id
 $templateId = 789; // int | Filter on a specific template id
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getEmailEventReport($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId);
+    $result = $apiInstance->getEmailEventReport($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalEmailsApi->getEmailEventReport: ', $e->getMessage(), PHP_EOL;
@@ -316,6 +491,7 @@ Name | Type | Description  | Notes
  **tags** | **string**| Filter the report for tags (serialized and urlencoded array) | [optional]
  **messageId** | **string**| Filter on a specific message id | [optional]
  **templateId** | **int**| Filter on a specific template id | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -333,7 +509,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getSmtpReport**
-> \SendinBlue\Client\Model\GetReports getSmtpReport($limit, $offset, $startDate, $endDate, $days, $tag)
+> \SendinBlue\Client\Model\GetReports getSmtpReport($limit, $offset, $startDate, $endDate, $days, $tag, $sort)
 
 Get your transactional email activity aggregated per day
 
@@ -363,9 +539,10 @@ $startDate = "startDate_example"; // string | Mandatory if endDate is used. Star
 $endDate = "endDate_example"; // string | Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD)
 $days = 56; // int | Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
 $tag = "tag_example"; // string | Tag of the emails
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getSmtpReport($limit, $offset, $startDate, $endDate, $days, $tag);
+    $result = $apiInstance->getSmtpReport($limit, $offset, $startDate, $endDate, $days, $tag, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalEmailsApi->getSmtpReport: ', $e->getMessage(), PHP_EOL;
@@ -383,6 +560,7 @@ Name | Type | Description  | Notes
  **endDate** | **string**| Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD) | [optional]
  **days** | **int**| Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; | [optional]
  **tag** | **string**| Tag of the emails | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -457,7 +635,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getSmtpTemplates**
-> \SendinBlue\Client\Model\GetSmtpTemplates getSmtpTemplates($templateStatus, $limit, $offset)
+> \SendinBlue\Client\Model\GetSmtpTemplates getSmtpTemplates($templateStatus, $limit, $offset, $sort)
 
 Get the list of email templates
 
@@ -484,9 +662,10 @@ $apiInstance = new SendinBlue\Client\Api\TransactionalEmailsApi(
 $templateStatus = true; // bool | Filter on the status of the template. Active = true, inactive = false
 $limit = 50; // int | Number of documents returned per page
 $offset = 0; // int | Index of the first document in the page
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getSmtpTemplates($templateStatus, $limit, $offset);
+    $result = $apiInstance->getSmtpTemplates($templateStatus, $limit, $offset, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalEmailsApi->getSmtpTemplates: ', $e->getMessage(), PHP_EOL;
@@ -501,6 +680,7 @@ Name | Type | Description  | Notes
  **templateStatus** | **bool**| Filter on the status of the template. Active &#x3D; true, inactive &#x3D; false | [optional]
  **limit** | **int**| Number of documents returned per page | [optional] [default to 50]
  **offset** | **int**| Index of the first document in the page | [optional] [default to 0]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -518,7 +698,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getTransacBlockedContacts**
-> \SendinBlue\Client\Model\GetTransacBlockedContacts getTransacBlockedContacts($startDate, $endDate, $limit, $offset, $senders)
+> \SendinBlue\Client\Model\GetTransacBlockedContacts getTransacBlockedContacts($startDate, $endDate, $limit, $offset, $senders, $sort)
 
 Get the list of blocked or unsubscribed transactional contacts
 
@@ -547,9 +727,10 @@ $endDate = "endDate_example"; // string | Mandatory if startDate is used. Ending
 $limit = 50; // int | Number of documents returned per page
 $offset = 0; // int | Index of the first document on the page
 $senders = array("senders_example"); // string[] | Comma separated list of emails of the senders from which contacts are blocked or unsubscribed
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getTransacBlockedContacts($startDate, $endDate, $limit, $offset, $senders);
+    $result = $apiInstance->getTransacBlockedContacts($startDate, $endDate, $limit, $offset, $senders, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalEmailsApi->getTransacBlockedContacts: ', $e->getMessage(), PHP_EOL;
@@ -566,6 +747,7 @@ Name | Type | Description  | Notes
  **limit** | **int**| Number of documents returned per page | [optional] [default to 50]
  **offset** | **int**| Index of the first document on the page | [optional] [default to 0]
  **senders** | [**string[]**](../Model/string.md)| Comma separated list of emails of the senders from which contacts are blocked or unsubscribed | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -640,7 +822,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getTransacEmailsList**
-> \SendinBlue\Client\Model\GetTransacEmailsList getTransacEmailsList($email, $templateId, $messageId, $startDate, $endDate)
+> \SendinBlue\Client\Model\GetTransacEmailsList getTransacEmailsList($email, $templateId, $messageId, $startDate, $endDate, $sort)
 
 Get the list of transactional emails on the basis of allowed filters
 
@@ -671,9 +853,10 @@ $templateId = 789; // int | Mandatory if email and messageId are not passed in q
 $messageId = "messageId_example"; // string | Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent.
 $startDate = new \DateTime("2013-10-20"); // \DateTime | Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month.
 $endDate = new \DateTime("2013-10-20"); // \DateTime | Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month.
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getTransacEmailsList($email, $templateId, $messageId, $startDate, $endDate);
+    $result = $apiInstance->getTransacEmailsList($email, $templateId, $messageId, $startDate, $endDate, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalEmailsApi->getTransacEmailsList: ', $e->getMessage(), PHP_EOL;
@@ -690,6 +873,7 @@ Name | Type | Description  | Notes
  **messageId** | **string**| Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent. | [optional]
  **startDate** | **\DateTime**| Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month. | [optional]
  **endDate** | **\DateTime**| Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month. | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Api/TransactionalSMSApi.md
+++ b/docs/Api/TransactionalSMSApi.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 
 
 # **getSmsEvents**
-> \SendinBlue\Client\Model\GetSmsEventReport getSmsEvents($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags)
+> \SendinBlue\Client\Model\GetSmsEventReport getSmsEvents($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags, $sort)
 
 Get all your SMS activity (unaggregated events)
 
@@ -43,9 +43,10 @@ $days = 56; // int | Number of days in the past including today (positive intege
 $phoneNumber = "phoneNumber_example"; // string | Filter the report for a specific phone number
 $event = "event_example"; // string | Filter the report for specific events
 $tags = "tags_example"; // string | Filter the report for specific tags passed as a serialized urlencoded array
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getSmsEvents($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags);
+    $result = $apiInstance->getSmsEvents($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalSMSApi->getSmsEvents: ', $e->getMessage(), PHP_EOL;
@@ -65,6 +66,7 @@ Name | Type | Description  | Notes
  **phoneNumber** | **string**| Filter the report for a specific phone number | [optional]
  **event** | **string**| Filter the report for specific events | [optional]
  **tags** | **string**| Filter the report for specific tags passed as a serialized urlencoded array | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 
@@ -145,7 +147,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 # **getTransacSmsReport**
-> \SendinBlue\Client\Model\GetTransacSmsReport getTransacSmsReport($startDate, $endDate, $days, $tag)
+> \SendinBlue\Client\Model\GetTransacSmsReport getTransacSmsReport($startDate, $endDate, $days, $tag, $sort)
 
 Get your SMS activity aggregated per day
 
@@ -173,9 +175,10 @@ $startDate = "startDate_example"; // string | Mandatory if endDate is used. Star
 $endDate = "endDate_example"; // string | Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
 $days = 56; // int | Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
 $tag = "tag_example"; // string | Filter on a tag
+$sort = "desc"; // string | Sort the results in the ascending/descending order of record creation
 
 try {
-    $result = $apiInstance->getTransacSmsReport($startDate, $endDate, $days, $tag);
+    $result = $apiInstance->getTransacSmsReport($startDate, $endDate, $days, $tag, $sort);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling TransactionalSMSApi->getTransacSmsReport: ', $e->getMessage(), PHP_EOL;
@@ -191,6 +194,7 @@ Name | Type | Description  | Notes
  **endDate** | **string**| Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report | [optional]
  **days** | **int**| Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; | [optional]
  **tag** | **string**| Filter on a tag | [optional]
+ **sort** | **string**| Sort the results in the ascending/descending order of record creation | [optional] [default to desc]
 
 ### Return type
 

--- a/docs/Model/BlockDomain.md
+++ b/docs/Model/BlockDomain.md
@@ -1,10 +1,9 @@
-# GetSmsCampaigns
+# BlockDomain
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**campaigns** | **object[]** |  | [optional] 
-**count** | **int** | Number of SMS campaigns retrieved | [optional] 
+**domain** | **string** | name of the domain to be blocked | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/CreateSmtpTemplateSender.md
+++ b/docs/Model/CreateSmtpTemplateSender.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **string** | Name of the sender. If not passed, will be set to default | [optional] 
-**email** | **string** | Email of the sender | 
+**email** | **string** | Email of the sender | [optional] 
 **id** | **int** | Select the sender for the template on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email). | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/docs/Model/GetChildDomain.md
+++ b/docs/Model/GetChildDomain.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**domain** | **string** | Sender domain | 
-**active** | **bool** | indicates whether a domain is verified or not | 
+**domain** | **string** | Sender domain | [optional] 
+**active** | **bool** | indicates whether a domain is verified or not | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetChildrenList.md
+++ b/docs/Model/GetChildrenList.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **children** | **object[]** | Your children&#39;s account information | [optional] 
-**count** | **int** | Number of child accounts | 
+**count** | **int** | Number of child accounts | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetEmailCampaign.md
+++ b/docs/Model/GetEmailCampaign.md
@@ -21,10 +21,10 @@ Name | Type | Description | Notes
 **footer** | **string** | Footer of the campaign | 
 **sender** | [**\SendinBlue\Client\Model\GetExtendedCampaignOverviewSender**](GetExtendedCampaignOverviewSender.md) |  | 
 **replyTo** | **string** | Email defined as the \&quot;Reply to\&quot; of the campaign | 
-**toField** | **string** | Customisation of the \&quot;to\&quot; field of the campaign | 
+**toField** | **string** | Customisation of the \&quot;to\&quot; field of the campaign | [optional] 
 **htmlContent** | **string** | HTML content of the campaign | 
 **shareLink** | **string** | Link to share the campaign on social medias | [optional] 
-**tag** | **string** | Tag of the campaign | 
+**tag** | **string** | Tag of the campaign | [optional] 
 **createdAt** | [**\DateTime**] | Creation UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **modifiedAt** | [**\DateTime**] | UTC date-time of last modification of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **inlineImageActivation** | **bool** | Status of inline image. inlineImageActivation &#x3D; false means image can’t be embedded, &amp; inlineImageActivation &#x3D; true means image can be embedded, in the email. | [optional] 

--- a/docs/Model/GetEmailCampaigns.md
+++ b/docs/Model/GetEmailCampaigns.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **campaigns** | **object[]** |  | [optional] 
-**count** | **int** | Number of Email campaigns retrieved | 
+**count** | **int** | Number of Email campaigns retrieved | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetEmailEventReportEvents.md
+++ b/docs/Model/GetEmailEventReportEvents.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **ip** | **string** | IP from which the user has opened the email or clicked on the link (only available if the event is opened or clicks) | [optional] 
 **link** | **string** | The link which is sent to the user (only available if the event is requests or opened or clicks) | [optional] 
 **from** | **string** | Sender email from which the emails are sent | [optional] 
+**templateId** | **int** | ID of the template (only available if the email is template based) | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetExtendedCampaignOverview.md
+++ b/docs/Model/GetExtendedCampaignOverview.md
@@ -21,10 +21,10 @@ Name | Type | Description | Notes
 **footer** | **string** | Footer of the campaign | 
 **sender** | [**\SendinBlue\Client\Model\GetExtendedCampaignOverviewSender**](GetExtendedCampaignOverviewSender.md) |  | 
 **replyTo** | **string** | Email defined as the \&quot;Reply to\&quot; of the campaign | 
-**toField** | **string** | Customisation of the \&quot;to\&quot; field of the campaign | 
+**toField** | **string** | Customisation of the \&quot;to\&quot; field of the campaign | [optional] 
 **htmlContent** | **string** | HTML content of the campaign | 
 **shareLink** | **string** | Link to share the campaign on social medias | [optional] 
-**tag** | **string** | Tag of the campaign | 
+**tag** | **string** | Tag of the campaign | [optional] 
 **createdAt** | [**\DateTime**] | Creation UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **modifiedAt** | [**\DateTime**] | UTC date-time of last modification of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **inlineImageActivation** | **bool** | Status of inline image. inlineImageActivation &#x3D; false means image can’t be embedded, &amp; inlineImageActivation &#x3D; true means image can be embedded, in the email. | [optional] 

--- a/docs/Model/GetFolderLists.md
+++ b/docs/Model/GetFolderLists.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lists** | **object[]** |  | 
-**count** | **int** | Number of lists in the folder | 
+**lists** | **object[]** |  | [optional] 
+**count** | **int** | Number of lists in the folder | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetLists.md
+++ b/docs/Model/GetLists.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**lists** | **object[]** | Listing of all the lists available in your account | 
-**count** | **int** | Number of lists in your account | 
+**lists** | **object[]** | Listing of all the lists available in your account | [optional] 
+**count** | **int** | Number of lists in your account | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetProcesses.md
+++ b/docs/Model/GetProcesses.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **processes** | [**\SendinBlue\Client\Model\GetProcess[]**](GetProcess.md) | List of processes available on your account | [optional] 
-**count** | **int** | Number of processes available on your account | 
+**count** | **int** | Number of processes available on your account | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetSmsCampaign.md
+++ b/docs/Model/GetSmsCampaign.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **name** | **string** | Name of the SMS Campaign | 
 **status** | **string** | Status of the SMS Campaign | 
 **content** | **string** | Content of the SMS Campaign | 
-**scheduledAt** | [**\DateTime**] | UTC date-time on which SMS campaign is scheduled. Should be in YYYY-MM-DDTHH:mm:ss.SSSZ format | 
+**scheduledAt** | [**\DateTime**] | UTC date-time on which SMS campaign is scheduled. Should be in YYYY-MM-DDTHH:mm:ss.SSSZ format | [optional] 
 **sender** | **string** | Sender of the SMS Campaign | 
 **createdAt** | [**\DateTime**] | Creation UTC date-time of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **modifiedAt** | [**\DateTime**] | UTC date-time of last modification of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 

--- a/docs/Model/GetSmsCampaignOverview.md
+++ b/docs/Model/GetSmsCampaignOverview.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **name** | **string** | Name of the SMS Campaign | 
 **status** | **string** | Status of the SMS Campaign | 
 **content** | **string** | Content of the SMS Campaign | 
-**scheduledAt** | [**\DateTime**] | UTC date-time on which SMS campaign is scheduled. Should be in YYYY-MM-DDTHH:mm:ss.SSSZ format | 
+**scheduledAt** | [**\DateTime**] | UTC date-time on which SMS campaign is scheduled. Should be in YYYY-MM-DDTHH:mm:ss.SSSZ format | [optional] 
 **sender** | **string** | Sender of the SMS Campaign | 
 **createdAt** | [**\DateTime**] | Creation UTC date-time of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 
 **modifiedAt** | [**\DateTime**] | UTC date-time of last modification of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ) | 

--- a/docs/Model/GetSmsEventReportEvents.md
+++ b/docs/Model/GetSmsEventReportEvents.md
@@ -3,10 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**phoneNumber** | **string** | Phone number which has generated the event | 
-**date** | [**\DateTime**] | UTC date-time on which the event has been generated | 
-**messageId** | **string** | Message ID which generated the event | 
-**event** | **string** | Event which occurred | 
+**phoneNumber** | **string** | Phone number which has generated the event | [optional] 
+**date** | [**\DateTime**] | UTC date-time on which the event has been generated | [optional] 
+**messageId** | **string** | Message ID which generated the event | [optional] 
+**event** | **string** | Event which occurred | [optional] 
 **reason** | **string** | Reason of bounce (only available if the event is hardbounce or softbounce) | [optional] 
 **reply** | **string** |  | [optional] 
 **tag** | **string** | Tag of the SMS which generated the event | [optional] 

--- a/docs/Model/GetTransacAggregatedSmsReport.md
+++ b/docs/Model/GetTransacAggregatedSmsReport.md
@@ -3,16 +3,16 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**range** | **string** | Time frame of the report | 
-**requests** | **int** | Number of requests for the timeframe | 
-**delivered** | **int** | Number of delivered SMS for the timeframe | 
-**hardBounces** | **int** | Number of hardbounces for the timeframe | 
-**softBounces** | **int** | Number of softbounces for the timeframe | 
-**blocked** | **int** | Number of blocked contact for the timeframe | 
-**unsubscribed** | **int** | Number of unsubscription for the timeframe | 
-**replied** | **int** | Number of answered SMS for the timeframe | 
-**accepted** | **int** | Number of accepted for the timeframe | 
-**rejected** | **int** | Number of rejected for the timeframe | 
+**range** | **string** | Time frame of the report | [optional] 
+**requests** | **int** | Number of requests for the timeframe | [optional] 
+**delivered** | **int** | Number of delivered SMS for the timeframe | [optional] 
+**hardBounces** | **int** | Number of hardbounces for the timeframe | [optional] 
+**softBounces** | **int** | Number of softbounces for the timeframe | [optional] 
+**blocked** | **int** | Number of blocked contact for the timeframe | [optional] 
+**unsubscribed** | **int** | Number of unsubscription for the timeframe | [optional] 
+**replied** | **int** | Number of answered SMS for the timeframe | [optional] 
+**accepted** | **int** | Number of accepted for the timeframe | [optional] 
+**rejected** | **int** | Number of rejected for the timeframe | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GetTransacSmsReportReports.md
+++ b/docs/Model/GetTransacSmsReportReports.md
@@ -3,16 +3,16 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**date** | [**\DateTime**] | Date for which statistics are retrieved | 
-**requests** | **int** | Number of requests for the date | 
-**delivered** | **int** | Number of delivered SMS for the date | 
-**hardBounces** | **int** | Number of hardbounces for the date | 
-**softBounces** | **int** | Number of softbounces for the date | 
-**blocked** | **int** | Number of blocked contact for the date | 
-**unsubscribed** | **int** | Number of unsubscription for the date | 
-**replied** | **int** | Number of answered SMS for the date | 
-**accepted** | **int** | Number of accepted for the date | 
-**rejected** | **int** | Number of rejected for the date | 
+**date** | [**\DateTime**] | Date for which statistics are retrieved | [optional] 
+**requests** | **int** | Number of requests for the date | [optional] 
+**delivered** | **int** | Number of delivered SMS for the date | [optional] 
+**hardBounces** | **int** | Number of hardbounces for the date | [optional] 
+**softBounces** | **int** | Number of softbounces for the date | [optional] 
+**blocked** | **int** | Number of blocked contact for the date | [optional] 
+**unsubscribed** | **int** | Number of unsubscription for the date | [optional] 
+**replied** | **int** | Number of answered SMS for the date | [optional] 
+**accepted** | **int** | Number of accepted for the date | [optional] 
+**rejected** | **int** | Number of rejected for the date | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/SendSmtpEmailSender.md
+++ b/docs/Model/SendSmtpEmailSender.md
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **string** | Name of the sender from which the emails will be sent. Maximum allowed characters are 70. | [optional] 
-**email** | **string** | Email of the sender from which the emails will be sent | 
-**id** | **int** | Id of the sender from which the emails will be sent | [optional] 
+**name** | **string** | Name of the sender from which the emails will be sent. Maximum allowed characters are 70. Applicable only when email is passed. | [optional] 
+**email** | **string** | Email of the sender from which the emails will be sent. Mandatory if sender id is not passed. | [optional] 
+**id** | **int** | Id of the sender from which the emails will be sent. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email). Mandatory if email is not passed. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/lib/Api/ContactsApi.php
+++ b/lib/Api/ContactsApi.php
@@ -3713,14 +3713,15 @@ class ContactsApi
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetContacts
      */
-    public function getContacts($limit = '50', $offset = '0', $modifiedSince = null)
+    public function getContacts($limit = '50', $offset = '0', $modifiedSince = null, $sort = 'desc')
     {
-        list($response) = $this->getContactsWithHttpInfo($limit, $offset, $modifiedSince);
+        list($response) = $this->getContactsWithHttpInfo($limit, $offset, $modifiedSince, $sort);
         return $response;
     }
 
@@ -3732,15 +3733,16 @@ class ContactsApi
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetContacts, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getContactsWithHttpInfo($limit = '50', $offset = '0', $modifiedSince = null)
+    public function getContactsWithHttpInfo($limit = '50', $offset = '0', $modifiedSince = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetContacts';
-        $request = $this->getContactsRequest($limit, $offset, $modifiedSince);
+        $request = $this->getContactsRequest($limit, $offset, $modifiedSince, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -3817,13 +3819,14 @@ class ContactsApi
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactsAsync($limit = '50', $offset = '0', $modifiedSince = null)
+    public function getContactsAsync($limit = '50', $offset = '0', $modifiedSince = null, $sort = 'desc')
     {
-        return $this->getContactsAsyncWithHttpInfo($limit, $offset, $modifiedSince)
+        return $this->getContactsAsyncWithHttpInfo($limit, $offset, $modifiedSince, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -3839,14 +3842,15 @@ class ContactsApi
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactsAsyncWithHttpInfo($limit = '50', $offset = '0', $modifiedSince = null)
+    public function getContactsAsyncWithHttpInfo($limit = '50', $offset = '0', $modifiedSince = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetContacts';
-        $request = $this->getContactsRequest($limit, $offset, $modifiedSince);
+        $request = $this->getContactsRequest($limit, $offset, $modifiedSince, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -3891,11 +3895,12 @@ class ContactsApi
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getContactsRequest($limit = '50', $offset = '0', $modifiedSince = null)
+    protected function getContactsRequest($limit = '50', $offset = '0', $modifiedSince = null, $sort = 'desc')
     {
         if ($limit !== null && $limit > 1000) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling ContactsApi.getContacts, must be smaller than or equal to 1000.');
@@ -3920,6 +3925,10 @@ class ContactsApi
         // query params
         if ($modifiedSince !== null) {
             $queryParams['modifiedSince'] = ObjectSerializer::toQueryValue($modifiedSince);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -4013,14 +4022,15 @@ class ContactsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetContacts
      */
-    public function getContactsFromList($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromList($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getContactsFromListWithHttpInfo($listId, $modifiedSince, $limit, $offset);
+        list($response) = $this->getContactsFromListWithHttpInfo($listId, $modifiedSince, $limit, $offset, $sort);
         return $response;
     }
 
@@ -4033,15 +4043,16 @@ class ContactsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetContacts, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getContactsFromListWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromListWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetContacts';
-        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset);
+        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4127,13 +4138,14 @@ class ContactsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactsFromListAsync($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromListAsync($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
-        return $this->getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince, $limit, $offset)
+        return $this->getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4150,14 +4162,15 @@ class ContactsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetContacts';
-        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset);
+        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4203,11 +4216,12 @@ class ContactsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getContactsFromListRequest($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    protected function getContactsFromListRequest($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         // verify the required parameter 'listId' is set
         if ($listId === null || (is_array($listId) && count($listId) === 0)) {
@@ -4238,6 +4252,10 @@ class ContactsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
         // path params
@@ -4633,14 +4651,15 @@ class ContactsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetFolderLists
      */
-    public function getFolderLists($folderId, $limit = '10', $offset = '0')
+    public function getFolderLists($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getFolderListsWithHttpInfo($folderId, $limit, $offset);
+        list($response) = $this->getFolderListsWithHttpInfo($folderId, $limit, $offset, $sort);
         return $response;
     }
 
@@ -4652,15 +4671,16 @@ class ContactsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetFolderLists, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getFolderListsWithHttpInfo($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsWithHttpInfo($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolderLists';
-        $request = $this->getFolderListsRequest($folderId, $limit, $offset);
+        $request = $this->getFolderListsRequest($folderId, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4745,13 +4765,14 @@ class ContactsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFolderListsAsync($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsAsync($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
-        return $this->getFolderListsAsyncWithHttpInfo($folderId, $limit, $offset)
+        return $this->getFolderListsAsyncWithHttpInfo($folderId, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4767,14 +4788,15 @@ class ContactsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFolderListsAsyncWithHttpInfo($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsAsyncWithHttpInfo($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolderLists';
-        $request = $this->getFolderListsRequest($folderId, $limit, $offset);
+        $request = $this->getFolderListsRequest($folderId, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4819,11 +4841,12 @@ class ContactsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getFolderListsRequest($folderId, $limit = '10', $offset = '0')
+    protected function getFolderListsRequest($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         // verify the required parameter 'folderId' is set
         if ($folderId === null || (is_array($folderId) && count($folderId) === 0)) {
@@ -4850,6 +4873,10 @@ class ContactsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
         // path params
@@ -4949,14 +4976,15 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetFolders
      */
-    public function getFolders($limit, $offset)
+    public function getFolders($limit, $offset, $sort = 'desc')
     {
-        list($response) = $this->getFoldersWithHttpInfo($limit, $offset);
+        list($response) = $this->getFoldersWithHttpInfo($limit, $offset, $sort);
         return $response;
     }
 
@@ -4967,15 +4995,16 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetFolders, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getFoldersWithHttpInfo($limit, $offset)
+    public function getFoldersWithHttpInfo($limit, $offset, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolders';
-        $request = $this->getFoldersRequest($limit, $offset);
+        $request = $this->getFoldersRequest($limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -5051,13 +5080,14 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFoldersAsync($limit, $offset)
+    public function getFoldersAsync($limit, $offset, $sort = 'desc')
     {
-        return $this->getFoldersAsyncWithHttpInfo($limit, $offset)
+        return $this->getFoldersAsyncWithHttpInfo($limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -5072,14 +5102,15 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFoldersAsyncWithHttpInfo($limit, $offset)
+    public function getFoldersAsyncWithHttpInfo($limit, $offset, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolders';
-        $request = $this->getFoldersRequest($limit, $offset);
+        $request = $this->getFoldersRequest($limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -5123,11 +5154,12 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getFoldersRequest($limit, $offset)
+    protected function getFoldersRequest($limit, $offset, $sort = 'desc')
     {
         // verify the required parameter 'limit' is set
         if ($limit === null || (is_array($limit) && count($limit) === 0)) {
@@ -5160,6 +5192,10 @@ class ContactsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -5546,14 +5582,15 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetLists
      */
-    public function getLists($limit = '10', $offset = '0')
+    public function getLists($limit = '10', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getListsWithHttpInfo($limit, $offset);
+        list($response) = $this->getListsWithHttpInfo($limit, $offset, $sort);
         return $response;
     }
 
@@ -5564,15 +5601,16 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetLists, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getListsWithHttpInfo($limit = '10', $offset = '0')
+    public function getListsWithHttpInfo($limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetLists';
-        $request = $this->getListsRequest($limit, $offset);
+        $request = $this->getListsRequest($limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -5648,13 +5686,14 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getListsAsync($limit = '10', $offset = '0')
+    public function getListsAsync($limit = '10', $offset = '0', $sort = 'desc')
     {
-        return $this->getListsAsyncWithHttpInfo($limit, $offset)
+        return $this->getListsAsyncWithHttpInfo($limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -5669,14 +5708,15 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getListsAsyncWithHttpInfo($limit = '10', $offset = '0')
+    public function getListsAsyncWithHttpInfo($limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetLists';
-        $request = $this->getListsRequest($limit, $offset);
+        $request = $this->getListsRequest($limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -5720,11 +5760,12 @@ class ContactsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getListsRequest($limit = '10', $offset = '0')
+    protected function getListsRequest($limit = '10', $offset = '0', $sort = 'desc')
     {
         if ($limit !== null && $limit > 50) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling ContactsApi.getLists, must be smaller than or equal to 50.');
@@ -5745,6 +5786,10 @@ class ContactsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/EmailCampaignsApi.php
+++ b/lib/Api/EmailCampaignsApi.php
@@ -1539,14 +1539,15 @@ class EmailCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number of documents per page (optional, default to 500)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetEmailCampaigns
      */
-    public function getEmailCampaigns($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getEmailCampaigns($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getEmailCampaignsWithHttpInfo($type, $status, $startDate, $endDate, $limit, $offset);
+        list($response) = $this->getEmailCampaignsWithHttpInfo($type, $status, $startDate, $endDate, $limit, $offset, $sort);
         return $response;
     }
 
@@ -1561,15 +1562,16 @@ class EmailCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number of documents per page (optional, default to 500)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetEmailCampaigns, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getEmailCampaignsWithHttpInfo($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getEmailCampaignsWithHttpInfo($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetEmailCampaigns';
-        $request = $this->getEmailCampaignsRequest($type, $status, $startDate, $endDate, $limit, $offset);
+        $request = $this->getEmailCampaignsRequest($type, $status, $startDate, $endDate, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1649,13 +1651,14 @@ class EmailCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number of documents per page (optional, default to 500)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getEmailCampaignsAsync($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getEmailCampaignsAsync($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
-        return $this->getEmailCampaignsAsyncWithHttpInfo($type, $status, $startDate, $endDate, $limit, $offset)
+        return $this->getEmailCampaignsAsyncWithHttpInfo($type, $status, $startDate, $endDate, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1674,14 +1677,15 @@ class EmailCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number of documents per page (optional, default to 500)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getEmailCampaignsAsyncWithHttpInfo($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getEmailCampaignsAsyncWithHttpInfo($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetEmailCampaigns';
-        $request = $this->getEmailCampaignsRequest($type, $status, $startDate, $endDate, $limit, $offset);
+        $request = $this->getEmailCampaignsRequest($type, $status, $startDate, $endDate, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1729,11 +1733,12 @@ class EmailCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number of documents per page (optional, default to 500)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getEmailCampaignsRequest($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    protected function getEmailCampaignsRequest($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
         if ($limit !== null && $limit > 1000) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling EmailCampaignsApi.getEmailCampaigns, must be smaller than or equal to 1000.');
@@ -1770,6 +1775,10 @@ class EmailCampaignsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/FoldersApi.php
+++ b/lib/Api/FoldersApi.php
@@ -930,14 +930,15 @@ class FoldersApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetFolderLists
      */
-    public function getFolderLists($folderId, $limit = '10', $offset = '0')
+    public function getFolderLists($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getFolderListsWithHttpInfo($folderId, $limit, $offset);
+        list($response) = $this->getFolderListsWithHttpInfo($folderId, $limit, $offset, $sort);
         return $response;
     }
 
@@ -949,15 +950,16 @@ class FoldersApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetFolderLists, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getFolderListsWithHttpInfo($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsWithHttpInfo($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolderLists';
-        $request = $this->getFolderListsRequest($folderId, $limit, $offset);
+        $request = $this->getFolderListsRequest($folderId, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1042,13 +1044,14 @@ class FoldersApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFolderListsAsync($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsAsync($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
-        return $this->getFolderListsAsyncWithHttpInfo($folderId, $limit, $offset)
+        return $this->getFolderListsAsyncWithHttpInfo($folderId, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1064,14 +1067,15 @@ class FoldersApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFolderListsAsyncWithHttpInfo($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsAsyncWithHttpInfo($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolderLists';
-        $request = $this->getFolderListsRequest($folderId, $limit, $offset);
+        $request = $this->getFolderListsRequest($folderId, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1116,11 +1120,12 @@ class FoldersApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getFolderListsRequest($folderId, $limit = '10', $offset = '0')
+    protected function getFolderListsRequest($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         // verify the required parameter 'folderId' is set
         if ($folderId === null || (is_array($folderId) && count($folderId) === 0)) {
@@ -1147,6 +1152,10 @@ class FoldersApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
         // path params
@@ -1246,14 +1255,15 @@ class FoldersApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetFolders
      */
-    public function getFolders($limit, $offset)
+    public function getFolders($limit, $offset, $sort = 'desc')
     {
-        list($response) = $this->getFoldersWithHttpInfo($limit, $offset);
+        list($response) = $this->getFoldersWithHttpInfo($limit, $offset, $sort);
         return $response;
     }
 
@@ -1264,15 +1274,16 @@ class FoldersApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetFolders, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getFoldersWithHttpInfo($limit, $offset)
+    public function getFoldersWithHttpInfo($limit, $offset, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolders';
-        $request = $this->getFoldersRequest($limit, $offset);
+        $request = $this->getFoldersRequest($limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1348,13 +1359,14 @@ class FoldersApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFoldersAsync($limit, $offset)
+    public function getFoldersAsync($limit, $offset, $sort = 'desc')
     {
-        return $this->getFoldersAsyncWithHttpInfo($limit, $offset)
+        return $this->getFoldersAsyncWithHttpInfo($limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1369,14 +1381,15 @@ class FoldersApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFoldersAsyncWithHttpInfo($limit, $offset)
+    public function getFoldersAsyncWithHttpInfo($limit, $offset, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolders';
-        $request = $this->getFoldersRequest($limit, $offset);
+        $request = $this->getFoldersRequest($limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1420,11 +1433,12 @@ class FoldersApi
      *
      * @param  int $limit Number of documents per page (required)
      * @param  int $offset Index of the first document of the page (required)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getFoldersRequest($limit, $offset)
+    protected function getFoldersRequest($limit, $offset, $sort = 'desc')
     {
         // verify the required parameter 'limit' is set
         if ($limit === null || (is_array($limit) && count($limit) === 0)) {
@@ -1457,6 +1471,10 @@ class FoldersApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/ListsApi.php
+++ b/lib/Api/ListsApi.php
@@ -945,14 +945,15 @@ class ListsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetContacts
      */
-    public function getContactsFromList($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromList($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getContactsFromListWithHttpInfo($listId, $modifiedSince, $limit, $offset);
+        list($response) = $this->getContactsFromListWithHttpInfo($listId, $modifiedSince, $limit, $offset, $sort);
         return $response;
     }
 
@@ -965,15 +966,16 @@ class ListsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetContacts, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getContactsFromListWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromListWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetContacts';
-        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset);
+        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1059,13 +1061,14 @@ class ListsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactsFromListAsync($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromListAsync($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
-        return $this->getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince, $limit, $offset)
+        return $this->getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1082,14 +1085,15 @@ class ListsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    public function getContactsFromListAsyncWithHttpInfo($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetContacts';
-        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset);
+        $request = $this->getContactsFromListRequest($listId, $modifiedSince, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1135,11 +1139,12 @@ class ListsApi
      * @param  \DateTime $modifiedSince Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. (optional)
      * @param  int $limit Number of documents per page (optional, default to 50)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getContactsFromListRequest($listId, $modifiedSince = null, $limit = '50', $offset = '0')
+    protected function getContactsFromListRequest($listId, $modifiedSince = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         // verify the required parameter 'listId' is set
         if ($listId === null || (is_array($listId) && count($listId) === 0)) {
@@ -1170,6 +1175,10 @@ class ListsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
         // path params
@@ -1270,14 +1279,15 @@ class ListsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetFolderLists
      */
-    public function getFolderLists($folderId, $limit = '10', $offset = '0')
+    public function getFolderLists($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getFolderListsWithHttpInfo($folderId, $limit, $offset);
+        list($response) = $this->getFolderListsWithHttpInfo($folderId, $limit, $offset, $sort);
         return $response;
     }
 
@@ -1289,15 +1299,16 @@ class ListsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetFolderLists, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getFolderListsWithHttpInfo($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsWithHttpInfo($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolderLists';
-        $request = $this->getFolderListsRequest($folderId, $limit, $offset);
+        $request = $this->getFolderListsRequest($folderId, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1382,13 +1393,14 @@ class ListsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFolderListsAsync($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsAsync($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
-        return $this->getFolderListsAsyncWithHttpInfo($folderId, $limit, $offset)
+        return $this->getFolderListsAsyncWithHttpInfo($folderId, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1404,14 +1416,15 @@ class ListsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getFolderListsAsyncWithHttpInfo($folderId, $limit = '10', $offset = '0')
+    public function getFolderListsAsyncWithHttpInfo($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetFolderLists';
-        $request = $this->getFolderListsRequest($folderId, $limit, $offset);
+        $request = $this->getFolderListsRequest($folderId, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1456,11 +1469,12 @@ class ListsApi
      * @param  int $folderId Id of the folder (required)
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getFolderListsRequest($folderId, $limit = '10', $offset = '0')
+    protected function getFolderListsRequest($folderId, $limit = '10', $offset = '0', $sort = 'desc')
     {
         // verify the required parameter 'folderId' is set
         if ($folderId === null || (is_array($folderId) && count($folderId) === 0)) {
@@ -1487,6 +1501,10 @@ class ListsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
         // path params
@@ -1881,14 +1899,15 @@ class ListsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetLists
      */
-    public function getLists($limit = '10', $offset = '0')
+    public function getLists($limit = '10', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getListsWithHttpInfo($limit, $offset);
+        list($response) = $this->getListsWithHttpInfo($limit, $offset, $sort);
         return $response;
     }
 
@@ -1899,15 +1918,16 @@ class ListsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetLists, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getListsWithHttpInfo($limit = '10', $offset = '0')
+    public function getListsWithHttpInfo($limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetLists';
-        $request = $this->getListsRequest($limit, $offset);
+        $request = $this->getListsRequest($limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1983,13 +2003,14 @@ class ListsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getListsAsync($limit = '10', $offset = '0')
+    public function getListsAsync($limit = '10', $offset = '0', $sort = 'desc')
     {
-        return $this->getListsAsyncWithHttpInfo($limit, $offset)
+        return $this->getListsAsyncWithHttpInfo($limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2004,14 +2025,15 @@ class ListsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getListsAsyncWithHttpInfo($limit = '10', $offset = '0')
+    public function getListsAsyncWithHttpInfo($limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetLists';
-        $request = $this->getListsRequest($limit, $offset);
+        $request = $this->getListsRequest($limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2055,11 +2077,12 @@ class ListsApi
      *
      * @param  int $limit Number of documents per page (optional, default to 10)
      * @param  int $offset Index of the first document of the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getListsRequest($limit = '10', $offset = '0')
+    protected function getListsRequest($limit = '10', $offset = '0', $sort = 'desc')
     {
         if ($limit !== null && $limit > 50) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling ListsApi.getLists, must be smaller than or equal to 50.');
@@ -2080,6 +2103,10 @@ class ListsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/ProcessApi.php
+++ b/lib/Api/ProcessApi.php
@@ -389,14 +389,15 @@ class ProcessApi
      *
      * @param  int $limit Number limitation for the result returned (optional, default to 10)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetProcesses
      */
-    public function getProcesses($limit = '10', $offset = '0')
+    public function getProcesses($limit = '10', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getProcessesWithHttpInfo($limit, $offset);
+        list($response) = $this->getProcessesWithHttpInfo($limit, $offset, $sort);
         return $response;
     }
 
@@ -407,15 +408,16 @@ class ProcessApi
      *
      * @param  int $limit Number limitation for the result returned (optional, default to 10)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetProcesses, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getProcessesWithHttpInfo($limit = '10', $offset = '0')
+    public function getProcessesWithHttpInfo($limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetProcesses';
-        $request = $this->getProcessesRequest($limit, $offset);
+        $request = $this->getProcessesRequest($limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -491,13 +493,14 @@ class ProcessApi
      *
      * @param  int $limit Number limitation for the result returned (optional, default to 10)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProcessesAsync($limit = '10', $offset = '0')
+    public function getProcessesAsync($limit = '10', $offset = '0', $sort = 'desc')
     {
-        return $this->getProcessesAsyncWithHttpInfo($limit, $offset)
+        return $this->getProcessesAsyncWithHttpInfo($limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -512,14 +515,15 @@ class ProcessApi
      *
      * @param  int $limit Number limitation for the result returned (optional, default to 10)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getProcessesAsyncWithHttpInfo($limit = '10', $offset = '0')
+    public function getProcessesAsyncWithHttpInfo($limit = '10', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetProcesses';
-        $request = $this->getProcessesRequest($limit, $offset);
+        $request = $this->getProcessesRequest($limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -563,11 +567,12 @@ class ProcessApi
      *
      * @param  int $limit Number limitation for the result returned (optional, default to 10)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getProcessesRequest($limit = '10', $offset = '0')
+    protected function getProcessesRequest($limit = '10', $offset = '0', $sort = 'desc')
     {
         if ($limit !== null && $limit > 50) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling ProcessApi.getProcesses, must be smaller than or equal to 50.');
@@ -588,6 +593,10 @@ class ProcessApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/SMSCampaignsApi.php
+++ b/lib/Api/SMSCampaignsApi.php
@@ -932,14 +932,15 @@ class SMSCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number limitation for the result returned (optional, default to 500)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetSmsCampaigns
      */
-    public function getSmsCampaigns($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getSmsCampaigns($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getSmsCampaignsWithHttpInfo($status, $startDate, $endDate, $limit, $offset);
+        list($response) = $this->getSmsCampaignsWithHttpInfo($status, $startDate, $endDate, $limit, $offset, $sort);
         return $response;
     }
 
@@ -953,15 +954,16 @@ class SMSCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number limitation for the result returned (optional, default to 500)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetSmsCampaigns, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getSmsCampaignsWithHttpInfo($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getSmsCampaignsWithHttpInfo($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetSmsCampaigns';
-        $request = $this->getSmsCampaignsRequest($status, $startDate, $endDate, $limit, $offset);
+        $request = $this->getSmsCampaignsRequest($status, $startDate, $endDate, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1040,13 +1042,14 @@ class SMSCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number limitation for the result returned (optional, default to 500)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmsCampaignsAsync($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getSmsCampaignsAsync($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
-        return $this->getSmsCampaignsAsyncWithHttpInfo($status, $startDate, $endDate, $limit, $offset)
+        return $this->getSmsCampaignsAsyncWithHttpInfo($status, $startDate, $endDate, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1064,14 +1067,15 @@ class SMSCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number limitation for the result returned (optional, default to 500)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmsCampaignsAsyncWithHttpInfo($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    public function getSmsCampaignsAsyncWithHttpInfo($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetSmsCampaigns';
-        $request = $this->getSmsCampaignsRequest($status, $startDate, $endDate, $limit, $offset);
+        $request = $this->getSmsCampaignsRequest($status, $startDate, $endDate, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1118,11 +1122,12 @@ class SMSCampaignsApi
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  int $limit Number limitation for the result returned (optional, default to 500)
      * @param  int $offset Beginning point in the list to retrieve from. (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getSmsCampaignsRequest($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0')
+    protected function getSmsCampaignsRequest($status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
     {
         if ($limit !== null && $limit > 1000) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling SMSCampaignsApi.getSmsCampaigns, must be smaller than or equal to 1000.');
@@ -1155,6 +1160,10 @@ class SMSCampaignsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/TransactionalEmailsApi.php
+++ b/lib/Api/TransactionalEmailsApi.php
@@ -88,6 +88,251 @@ class TransactionalEmailsApi
     }
 
     /**
+     * Operation blockNewDomain
+     *
+     * Add a new domain to the list of blocked domains
+     *
+     * @param  \SendinBlue\Client\Model\BlockDomain $blockDomain blockDomain (required)
+     *
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function blockNewDomain($blockDomain)
+    {
+        $this->blockNewDomainWithHttpInfo($blockDomain);
+    }
+
+    /**
+     * Operation blockNewDomainWithHttpInfo
+     *
+     * Add a new domain to the list of blocked domains
+     *
+     * @param  \SendinBlue\Client\Model\BlockDomain $blockDomain (required)
+     *
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function blockNewDomainWithHttpInfo($blockDomain)
+    {
+        $returnType = '';
+        $request = $this->blockNewDomainRequest($blockDomain);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 400:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SendinBlue\Client\Model\ErrorModel',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation blockNewDomainAsync
+     *
+     * Add a new domain to the list of blocked domains
+     *
+     * @param  \SendinBlue\Client\Model\BlockDomain $blockDomain (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function blockNewDomainAsync($blockDomain)
+    {
+        return $this->blockNewDomainAsyncWithHttpInfo($blockDomain)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation blockNewDomainAsyncWithHttpInfo
+     *
+     * Add a new domain to the list of blocked domains
+     *
+     * @param  \SendinBlue\Client\Model\BlockDomain $blockDomain (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function blockNewDomainAsyncWithHttpInfo($blockDomain)
+    {
+        $returnType = '';
+        $request = $this->blockNewDomainRequest($blockDomain);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'blockNewDomain'
+     *
+     * @param  \SendinBlue\Client\Model\BlockDomain $blockDomain (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function blockNewDomainRequest($blockDomain)
+    {
+        // verify the required parameter 'blockDomain' is set
+        if ($blockDomain === null || (is_array($blockDomain) && count($blockDomain) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $blockDomain when calling blockNewDomain'
+            );
+        }
+
+        $resourcePath = '/smtp/blockedDomains';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // body params
+        $_tempBody = null;
+        if (isset($blockDomain)) {
+            $_tempBody = $blockDomain;
+        }
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                ['application/json']
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                ['application/json'],
+                ['application/json']
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            
+            if($headers['Content-Type'] === 'application/json') {
+                // \stdClass has no __toString(), so we should encode it manually
+                if ($httpBody instanceof \stdClass) {
+                    $httpBody = \GuzzleHttp\json_encode($httpBody);
+                }
+                // array has no __toString(), so we should encode it manually
+                if(is_array($httpBody)) {
+                    $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($httpBody));
+                }
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('api-key');
+        if ($apiKey !== null) {
+            $headers['api-key'] = $apiKey;
+        }
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('partner-key');
+        if ($apiKey !== null) {
+            $headers['partner-key'] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'POST',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Operation createSmtpTemplate
      *
      * Create an email template
@@ -363,6 +608,256 @@ class TransactionalEmailsApi
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'POST',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation deleteBlockedDomain
+     *
+     * Unblock an existing domain from the list of blocked domains
+     *
+     * @param  string $domain The name of the domain to be deleted (required)
+     *
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function deleteBlockedDomain($domain)
+    {
+        $this->deleteBlockedDomainWithHttpInfo($domain);
+    }
+
+    /**
+     * Operation deleteBlockedDomainWithHttpInfo
+     *
+     * Unblock an existing domain from the list of blocked domains
+     *
+     * @param  string $domain The name of the domain to be deleted (required)
+     *
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function deleteBlockedDomainWithHttpInfo($domain)
+    {
+        $returnType = '';
+        $request = $this->deleteBlockedDomainRequest($domain);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 400:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SendinBlue\Client\Model\ErrorModel',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation deleteBlockedDomainAsync
+     *
+     * Unblock an existing domain from the list of blocked domains
+     *
+     * @param  string $domain The name of the domain to be deleted (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function deleteBlockedDomainAsync($domain)
+    {
+        return $this->deleteBlockedDomainAsyncWithHttpInfo($domain)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation deleteBlockedDomainAsyncWithHttpInfo
+     *
+     * Unblock an existing domain from the list of blocked domains
+     *
+     * @param  string $domain The name of the domain to be deleted (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function deleteBlockedDomainAsyncWithHttpInfo($domain)
+    {
+        $returnType = '';
+        $request = $this->deleteBlockedDomainRequest($domain);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'deleteBlockedDomain'
+     *
+     * @param  string $domain The name of the domain to be deleted (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function deleteBlockedDomainRequest($domain)
+    {
+        // verify the required parameter 'domain' is set
+        if ($domain === null || (is_array($domain) && count($domain) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $domain when calling deleteBlockedDomain'
+            );
+        }
+
+        $resourcePath = '/smtp/blockedDomains/{domain}';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+        // path params
+        if ($domain !== null) {
+            $resourcePath = str_replace(
+                '{' . 'domain' . '}',
+                ObjectSerializer::toPathValue($domain),
+                $resourcePath
+            );
+        }
+
+        // body params
+        $_tempBody = null;
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                ['application/json']
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                ['application/json'],
+                ['application/json']
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            
+            if($headers['Content-Type'] === 'application/json') {
+                // \stdClass has no __toString(), so we should encode it manually
+                if ($httpBody instanceof \stdClass) {
+                    $httpBody = \GuzzleHttp\json_encode($httpBody);
+                }
+                // array has no __toString(), so we should encode it manually
+                if(is_array($httpBody)) {
+                    $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($httpBody));
+                }
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('api-key');
+        if ($apiKey !== null) {
+            $headers['api-key'] = $apiKey;
+        }
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('partner-key');
+        if ($apiKey !== null) {
+            $headers['partner-key'] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody
@@ -1171,6 +1666,266 @@ class TransactionalEmailsApi
     }
 
     /**
+     * Operation getBlockedDomains
+     *
+     * Get the list of blocked domains
+     *
+     *
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return \SendinBlue\Client\Model\GetBlockedDomains
+     */
+    public function getBlockedDomains()
+    {
+        list($response) = $this->getBlockedDomainsWithHttpInfo();
+        return $response;
+    }
+
+    /**
+     * Operation getBlockedDomainsWithHttpInfo
+     *
+     * Get the list of blocked domains
+     *
+     *
+     * @throws \SendinBlue\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of \SendinBlue\Client\Model\GetBlockedDomains, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function getBlockedDomainsWithHttpInfo()
+    {
+        $returnType = '\SendinBlue\Client\Model\GetBlockedDomains';
+        $request = $this->getBlockedDomainsRequest();
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            $responseBody = $response->getBody();
+            if ($returnType === '\SplFileObject') {
+                $content = $responseBody; //stream goes to serializer
+            } else {
+                $content = $responseBody->getContents();
+                if ($returnType !== 'string') {
+                    $content = json_decode($content);
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SendinBlue\Client\Model\GetBlockedDomains',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation getBlockedDomainsAsync
+     *
+     * Get the list of blocked domains
+     *
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function getBlockedDomainsAsync()
+    {
+        return $this->getBlockedDomainsAsyncWithHttpInfo()
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation getBlockedDomainsAsyncWithHttpInfo
+     *
+     * Get the list of blocked domains
+     *
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function getBlockedDomainsAsyncWithHttpInfo()
+    {
+        $returnType = '\SendinBlue\Client\Model\GetBlockedDomains';
+        $request = $this->getBlockedDomainsRequest();
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    $responseBody = $response->getBody();
+                    if ($returnType === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = $responseBody->getContents();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'getBlockedDomains'
+     *
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function getBlockedDomainsRequest()
+    {
+
+        $resourcePath = '/smtp/blockedDomains';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // body params
+        $_tempBody = null;
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                ['application/json']
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                ['application/json'],
+                ['application/json']
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            
+            if($headers['Content-Type'] === 'application/json') {
+                // \stdClass has no __toString(), so we should encode it manually
+                if ($httpBody instanceof \stdClass) {
+                    $httpBody = \GuzzleHttp\json_encode($httpBody);
+                }
+                // array has no __toString(), so we should encode it manually
+                if(is_array($httpBody)) {
+                    $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($httpBody));
+                }
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('api-key');
+        if ($apiKey !== null) {
+            $headers['api-key'] = $apiKey;
+        }
+        // this endpoint requires API key authentication
+        $apiKey = $this->config->getApiKeyWithPrefix('partner-key');
+        if ($apiKey !== null) {
+            $headers['partner-key'] = $apiKey;
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Operation getEmailEventReport
      *
      * Get all your transactional email activity (unaggregated events)
@@ -1185,14 +1940,15 @@ class TransactionalEmailsApi
      * @param  string $tags Filter the report for tags (serialized and urlencoded array) (optional)
      * @param  string $messageId Filter on a specific message id (optional)
      * @param  int $templateId Filter on a specific template id (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetEmailEventReport
      */
-    public function getEmailEventReport($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null)
+    public function getEmailEventReport($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null, $sort = 'desc')
     {
-        list($response) = $this->getEmailEventReportWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId);
+        list($response) = $this->getEmailEventReportWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId, $sort);
         return $response;
     }
 
@@ -1211,15 +1967,16 @@ class TransactionalEmailsApi
      * @param  string $tags Filter the report for tags (serialized and urlencoded array) (optional)
      * @param  string $messageId Filter on a specific message id (optional)
      * @param  int $templateId Filter on a specific template id (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetEmailEventReport, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getEmailEventReportWithHttpInfo($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null)
+    public function getEmailEventReportWithHttpInfo($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetEmailEventReport';
-        $request = $this->getEmailEventReportRequest($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId);
+        $request = $this->getEmailEventReportRequest($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1303,13 +2060,14 @@ class TransactionalEmailsApi
      * @param  string $tags Filter the report for tags (serialized and urlencoded array) (optional)
      * @param  string $messageId Filter on a specific message id (optional)
      * @param  int $templateId Filter on a specific template id (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getEmailEventReportAsync($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null)
+    public function getEmailEventReportAsync($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null, $sort = 'desc')
     {
-        return $this->getEmailEventReportAsyncWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId)
+        return $this->getEmailEventReportAsyncWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1332,14 +2090,15 @@ class TransactionalEmailsApi
      * @param  string $tags Filter the report for tags (serialized and urlencoded array) (optional)
      * @param  string $messageId Filter on a specific message id (optional)
      * @param  int $templateId Filter on a specific template id (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getEmailEventReportAsyncWithHttpInfo($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null)
+    public function getEmailEventReportAsyncWithHttpInfo($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetEmailEventReport';
-        $request = $this->getEmailEventReportRequest($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId);
+        $request = $this->getEmailEventReportRequest($limit, $offset, $startDate, $endDate, $days, $email, $event, $tags, $messageId, $templateId, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1391,11 +2150,12 @@ class TransactionalEmailsApi
      * @param  string $tags Filter the report for tags (serialized and urlencoded array) (optional)
      * @param  string $messageId Filter on a specific message id (optional)
      * @param  int $templateId Filter on a specific template id (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getEmailEventReportRequest($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null)
+    protected function getEmailEventReportRequest($limit = '50', $offset = '0', $startDate = null, $endDate = null, $days = null, $email = null, $event = null, $tags = null, $messageId = null, $templateId = null, $sort = 'desc')
     {
         if ($limit !== null && $limit > 100) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getEmailEventReport, must be smaller than or equal to 100.');
@@ -1448,6 +2208,10 @@ class TransactionalEmailsApi
         // query params
         if ($templateId !== null) {
             $queryParams['templateId'] = ObjectSerializer::toQueryValue($templateId);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -1543,14 +2307,15 @@ class TransactionalEmailsApi
      * @param  string $endDate Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD) (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Tag of the emails (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetReports
      */
-    public function getSmtpReport($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getSmtpReport($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
-        list($response) = $this->getSmtpReportWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $tag);
+        list($response) = $this->getSmtpReportWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $tag, $sort);
         return $response;
     }
 
@@ -1565,15 +2330,16 @@ class TransactionalEmailsApi
      * @param  string $endDate Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD) (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Tag of the emails (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetReports, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getSmtpReportWithHttpInfo($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getSmtpReportWithHttpInfo($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetReports';
-        $request = $this->getSmtpReportRequest($limit, $offset, $startDate, $endDate, $days, $tag);
+        $request = $this->getSmtpReportRequest($limit, $offset, $startDate, $endDate, $days, $tag, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1653,13 +2419,14 @@ class TransactionalEmailsApi
      * @param  string $endDate Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD) (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Tag of the emails (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmtpReportAsync($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getSmtpReportAsync($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
-        return $this->getSmtpReportAsyncWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $tag)
+        return $this->getSmtpReportAsyncWithHttpInfo($limit, $offset, $startDate, $endDate, $days, $tag, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1678,14 +2445,15 @@ class TransactionalEmailsApi
      * @param  string $endDate Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD) (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Tag of the emails (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmtpReportAsyncWithHttpInfo($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getSmtpReportAsyncWithHttpInfo($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetReports';
-        $request = $this->getSmtpReportRequest($limit, $offset, $startDate, $endDate, $days, $tag);
+        $request = $this->getSmtpReportRequest($limit, $offset, $startDate, $endDate, $days, $tag, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1733,11 +2501,12 @@ class TransactionalEmailsApi
      * @param  string $endDate Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD) (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Tag of the emails (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getSmtpReportRequest($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null)
+    protected function getSmtpReportRequest($limit = '10', $offset = '0', $startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
         if ($limit !== null && $limit > 30) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getSmtpReport, must be smaller than or equal to 30.');
@@ -1774,6 +2543,10 @@ class TransactionalEmailsApi
         // query params
         if ($tag !== null) {
             $queryParams['tag'] = ObjectSerializer::toQueryValue($tag);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -2161,14 +2934,15 @@ class TransactionalEmailsApi
      * @param  bool $templateStatus Filter on the status of the template. Active &#x3D; true, inactive &#x3D; false (optional)
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetSmtpTemplates
      */
-    public function getSmtpTemplates($templateStatus = null, $limit = '50', $offset = '0')
+    public function getSmtpTemplates($templateStatus = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
-        list($response) = $this->getSmtpTemplatesWithHttpInfo($templateStatus, $limit, $offset);
+        list($response) = $this->getSmtpTemplatesWithHttpInfo($templateStatus, $limit, $offset, $sort);
         return $response;
     }
 
@@ -2180,15 +2954,16 @@ class TransactionalEmailsApi
      * @param  bool $templateStatus Filter on the status of the template. Active &#x3D; true, inactive &#x3D; false (optional)
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetSmtpTemplates, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getSmtpTemplatesWithHttpInfo($templateStatus = null, $limit = '50', $offset = '0')
+    public function getSmtpTemplatesWithHttpInfo($templateStatus = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetSmtpTemplates';
-        $request = $this->getSmtpTemplatesRequest($templateStatus, $limit, $offset);
+        $request = $this->getSmtpTemplatesRequest($templateStatus, $limit, $offset, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2265,13 +3040,14 @@ class TransactionalEmailsApi
      * @param  bool $templateStatus Filter on the status of the template. Active &#x3D; true, inactive &#x3D; false (optional)
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmtpTemplatesAsync($templateStatus = null, $limit = '50', $offset = '0')
+    public function getSmtpTemplatesAsync($templateStatus = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
-        return $this->getSmtpTemplatesAsyncWithHttpInfo($templateStatus, $limit, $offset)
+        return $this->getSmtpTemplatesAsyncWithHttpInfo($templateStatus, $limit, $offset, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2287,14 +3063,15 @@ class TransactionalEmailsApi
      * @param  bool $templateStatus Filter on the status of the template. Active &#x3D; true, inactive &#x3D; false (optional)
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmtpTemplatesAsyncWithHttpInfo($templateStatus = null, $limit = '50', $offset = '0')
+    public function getSmtpTemplatesAsyncWithHttpInfo($templateStatus = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetSmtpTemplates';
-        $request = $this->getSmtpTemplatesRequest($templateStatus, $limit, $offset);
+        $request = $this->getSmtpTemplatesRequest($templateStatus, $limit, $offset, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2339,11 +3116,12 @@ class TransactionalEmailsApi
      * @param  bool $templateStatus Filter on the status of the template. Active &#x3D; true, inactive &#x3D; false (optional)
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getSmtpTemplatesRequest($templateStatus = null, $limit = '50', $offset = '0')
+    protected function getSmtpTemplatesRequest($templateStatus = null, $limit = '50', $offset = '0', $sort = 'desc')
     {
         if ($limit !== null && $limit > 1000) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getSmtpTemplates, must be smaller than or equal to 1000.');
@@ -2368,6 +3146,10 @@ class TransactionalEmailsApi
         // query params
         if ($offset !== null) {
             $queryParams['offset'] = ObjectSerializer::toQueryValue($offset);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -2462,14 +3244,15 @@ class TransactionalEmailsApi
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document on the page (optional, default to 0)
      * @param  string[] $senders Comma separated list of emails of the senders from which contacts are blocked or unsubscribed (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetTransacBlockedContacts
      */
-    public function getTransacBlockedContacts($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null)
+    public function getTransacBlockedContacts($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null, $sort = 'desc')
     {
-        list($response) = $this->getTransacBlockedContactsWithHttpInfo($startDate, $endDate, $limit, $offset, $senders);
+        list($response) = $this->getTransacBlockedContactsWithHttpInfo($startDate, $endDate, $limit, $offset, $senders, $sort);
         return $response;
     }
 
@@ -2483,15 +3266,16 @@ class TransactionalEmailsApi
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document on the page (optional, default to 0)
      * @param  string[] $senders Comma separated list of emails of the senders from which contacts are blocked or unsubscribed (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetTransacBlockedContacts, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getTransacBlockedContactsWithHttpInfo($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null)
+    public function getTransacBlockedContactsWithHttpInfo($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetTransacBlockedContacts';
-        $request = $this->getTransacBlockedContactsRequest($startDate, $endDate, $limit, $offset, $senders);
+        $request = $this->getTransacBlockedContactsRequest($startDate, $endDate, $limit, $offset, $senders, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2570,13 +3354,14 @@ class TransactionalEmailsApi
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document on the page (optional, default to 0)
      * @param  string[] $senders Comma separated list of emails of the senders from which contacts are blocked or unsubscribed (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getTransacBlockedContactsAsync($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null)
+    public function getTransacBlockedContactsAsync($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null, $sort = 'desc')
     {
-        return $this->getTransacBlockedContactsAsyncWithHttpInfo($startDate, $endDate, $limit, $offset, $senders)
+        return $this->getTransacBlockedContactsAsyncWithHttpInfo($startDate, $endDate, $limit, $offset, $senders, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2594,14 +3379,15 @@ class TransactionalEmailsApi
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document on the page (optional, default to 0)
      * @param  string[] $senders Comma separated list of emails of the senders from which contacts are blocked or unsubscribed (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getTransacBlockedContactsAsyncWithHttpInfo($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null)
+    public function getTransacBlockedContactsAsyncWithHttpInfo($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetTransacBlockedContacts';
-        $request = $this->getTransacBlockedContactsRequest($startDate, $endDate, $limit, $offset, $senders);
+        $request = $this->getTransacBlockedContactsRequest($startDate, $endDate, $limit, $offset, $senders, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2648,11 +3434,12 @@ class TransactionalEmailsApi
      * @param  int $limit Number of documents returned per page (optional, default to 50)
      * @param  int $offset Index of the first document on the page (optional, default to 0)
      * @param  string[] $senders Comma separated list of emails of the senders from which contacts are blocked or unsubscribed (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getTransacBlockedContactsRequest($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null)
+    protected function getTransacBlockedContactsRequest($startDate = null, $endDate = null, $limit = '50', $offset = '0', $senders = null, $sort = 'desc')
     {
         if ($limit !== null && $limit > 100) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalEmailsApi.getTransacBlockedContacts, must be smaller than or equal to 100.');
@@ -2688,6 +3475,10 @@ class TransactionalEmailsApi
         } else
         if ($senders !== null) {
             $queryParams['senders'] = ObjectSerializer::toQueryValue($senders);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -3061,14 +3852,15 @@ class TransactionalEmailsApi
      * @param  string $messageId Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent. (optional)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetTransacEmailsList
      */
-    public function getTransacEmailsList($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null)
+    public function getTransacEmailsList($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null, $sort = 'desc')
     {
-        list($response) = $this->getTransacEmailsListWithHttpInfo($email, $templateId, $messageId, $startDate, $endDate);
+        list($response) = $this->getTransacEmailsListWithHttpInfo($email, $templateId, $messageId, $startDate, $endDate, $sort);
         return $response;
     }
 
@@ -3082,15 +3874,16 @@ class TransactionalEmailsApi
      * @param  string $messageId Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent. (optional)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetTransacEmailsList, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getTransacEmailsListWithHttpInfo($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null)
+    public function getTransacEmailsListWithHttpInfo($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetTransacEmailsList';
-        $request = $this->getTransacEmailsListRequest($email, $templateId, $messageId, $startDate, $endDate);
+        $request = $this->getTransacEmailsListRequest($email, $templateId, $messageId, $startDate, $endDate, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -3169,13 +3962,14 @@ class TransactionalEmailsApi
      * @param  string $messageId Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent. (optional)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getTransacEmailsListAsync($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null)
+    public function getTransacEmailsListAsync($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null, $sort = 'desc')
     {
-        return $this->getTransacEmailsListAsyncWithHttpInfo($email, $templateId, $messageId, $startDate, $endDate)
+        return $this->getTransacEmailsListAsyncWithHttpInfo($email, $templateId, $messageId, $startDate, $endDate, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -3193,14 +3987,15 @@ class TransactionalEmailsApi
      * @param  string $messageId Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent. (optional)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getTransacEmailsListAsyncWithHttpInfo($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null)
+    public function getTransacEmailsListAsyncWithHttpInfo($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetTransacEmailsList';
-        $request = $this->getTransacEmailsListRequest($email, $templateId, $messageId, $startDate, $endDate);
+        $request = $this->getTransacEmailsListRequest($email, $templateId, $messageId, $startDate, $endDate, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -3247,11 +4042,12 @@ class TransactionalEmailsApi
      * @param  string $messageId Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent. (optional)
      * @param  \DateTime $startDate Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
      * @param  \DateTime $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month. (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getTransacEmailsListRequest($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null)
+    protected function getTransacEmailsListRequest($email = null, $templateId = null, $messageId = null, $startDate = null, $endDate = null, $sort = 'desc')
     {
 
         $resourcePath = '/smtp/emails';
@@ -3280,6 +4076,10 @@ class TransactionalEmailsApi
         // query params
         if ($endDate !== null) {
             $queryParams['endDate'] = ObjectSerializer::toQueryValue($endDate);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Api/TransactionalSMSApi.php
+++ b/lib/Api/TransactionalSMSApi.php
@@ -100,14 +100,15 @@ class TransactionalSMSApi
      * @param  string $phoneNumber Filter the report for a specific phone number (optional)
      * @param  string $event Filter the report for specific events (optional)
      * @param  string $tags Filter the report for specific tags passed as a serialized urlencoded array (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetSmsEventReport
      */
-    public function getSmsEvents($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null)
+    public function getSmsEvents($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null, $sort = 'desc')
     {
-        list($response) = $this->getSmsEventsWithHttpInfo($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags);
+        list($response) = $this->getSmsEventsWithHttpInfo($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags, $sort);
         return $response;
     }
 
@@ -124,15 +125,16 @@ class TransactionalSMSApi
      * @param  string $phoneNumber Filter the report for a specific phone number (optional)
      * @param  string $event Filter the report for specific events (optional)
      * @param  string $tags Filter the report for specific tags passed as a serialized urlencoded array (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetSmsEventReport, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getSmsEventsWithHttpInfo($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null)
+    public function getSmsEventsWithHttpInfo($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetSmsEventReport';
-        $request = $this->getSmsEventsRequest($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags);
+        $request = $this->getSmsEventsRequest($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -214,13 +216,14 @@ class TransactionalSMSApi
      * @param  string $phoneNumber Filter the report for a specific phone number (optional)
      * @param  string $event Filter the report for specific events (optional)
      * @param  string $tags Filter the report for specific tags passed as a serialized urlencoded array (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmsEventsAsync($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null)
+    public function getSmsEventsAsync($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null, $sort = 'desc')
     {
-        return $this->getSmsEventsAsyncWithHttpInfo($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags)
+        return $this->getSmsEventsAsyncWithHttpInfo($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -241,14 +244,15 @@ class TransactionalSMSApi
      * @param  string $phoneNumber Filter the report for a specific phone number (optional)
      * @param  string $event Filter the report for specific events (optional)
      * @param  string $tags Filter the report for specific tags passed as a serialized urlencoded array (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getSmsEventsAsyncWithHttpInfo($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null)
+    public function getSmsEventsAsyncWithHttpInfo($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetSmsEventReport';
-        $request = $this->getSmsEventsRequest($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags);
+        $request = $this->getSmsEventsRequest($limit, $startDate, $endDate, $offset, $days, $phoneNumber, $event, $tags, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -298,11 +302,12 @@ class TransactionalSMSApi
      * @param  string $phoneNumber Filter the report for a specific phone number (optional)
      * @param  string $event Filter the report for specific events (optional)
      * @param  string $tags Filter the report for specific tags passed as a serialized urlencoded array (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getSmsEventsRequest($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null)
+    protected function getSmsEventsRequest($limit = '50', $startDate = null, $endDate = null, $offset = '0', $days = null, $phoneNumber = null, $event = null, $tags = null, $sort = 'desc')
     {
         if ($limit !== null && $limit > 100) {
             throw new \InvalidArgumentException('invalid value for "$limit" when calling TransactionalSMSApi.getSmsEvents, must be smaller than or equal to 100.');
@@ -347,6 +352,10 @@ class TransactionalSMSApi
         // query params
         if ($tags !== null) {
             $queryParams['tags'] = ObjectSerializer::toQueryValue($tags);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 
@@ -744,14 +753,15 @@ class TransactionalSMSApi
      * @param  string $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Filter on a tag (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetTransacSmsReport
      */
-    public function getTransacSmsReport($startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getTransacSmsReport($startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
-        list($response) = $this->getTransacSmsReportWithHttpInfo($startDate, $endDate, $days, $tag);
+        list($response) = $this->getTransacSmsReportWithHttpInfo($startDate, $endDate, $days, $tag, $sort);
         return $response;
     }
 
@@ -764,15 +774,16 @@ class TransactionalSMSApi
      * @param  string $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Filter on a tag (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \SendinBlue\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \SendinBlue\Client\Model\GetTransacSmsReport, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getTransacSmsReportWithHttpInfo($startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getTransacSmsReportWithHttpInfo($startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetTransacSmsReport';
-        $request = $this->getTransacSmsReportRequest($startDate, $endDate, $days, $tag);
+        $request = $this->getTransacSmsReportRequest($startDate, $endDate, $days, $tag, $sort);
 
         try {
             $options = $this->createHttpClientOption();
@@ -850,13 +861,14 @@ class TransactionalSMSApi
      * @param  string $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Filter on a tag (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getTransacSmsReportAsync($startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getTransacSmsReportAsync($startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
-        return $this->getTransacSmsReportAsyncWithHttpInfo($startDate, $endDate, $days, $tag)
+        return $this->getTransacSmsReportAsyncWithHttpInfo($startDate, $endDate, $days, $tag, $sort)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -873,14 +885,15 @@ class TransactionalSMSApi
      * @param  string $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Filter on a tag (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getTransacSmsReportAsyncWithHttpInfo($startDate = null, $endDate = null, $days = null, $tag = null)
+    public function getTransacSmsReportAsyncWithHttpInfo($startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
         $returnType = '\SendinBlue\Client\Model\GetTransacSmsReport';
-        $request = $this->getTransacSmsReportRequest($startDate, $endDate, $days, $tag);
+        $request = $this->getTransacSmsReportRequest($startDate, $endDate, $days, $tag, $sort);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -926,11 +939,12 @@ class TransactionalSMSApi
      * @param  string $endDate Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report (optional)
      * @param  int $days Number of days in the past including today (positive integer). Not compatible with &#39;startDate&#39; and &#39;endDate&#39; (optional)
      * @param  string $tag Filter on a tag (optional)
+     * @param  string $sort Sort the results in the ascending/descending order of record creation (optional, default to desc)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function getTransacSmsReportRequest($startDate = null, $endDate = null, $days = null, $tag = null)
+    protected function getTransacSmsReportRequest($startDate = null, $endDate = null, $days = null, $tag = null, $sort = 'desc')
     {
 
         $resourcePath = '/transactionalSMS/statistics/reports';
@@ -955,6 +969,10 @@ class TransactionalSMSApi
         // query params
         if ($tag !== null) {
             $queryParams['tag'] = ObjectSerializer::toQueryValue($tag);
+        }
+        // query params
+        if ($sort !== null) {
+            $queryParams['sort'] = ObjectSerializer::toQueryValue($sort);
         }
 
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -37,6 +37,9 @@ namespace SendinBlue\Client;
  * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
+
+$GLOBALS['version'] = '7.3.0';
+
 class Configuration
 {
     private static $defaultConfiguration;
@@ -84,13 +87,6 @@ class Configuration
     protected $host = 'https://api.sendinblue.com/v3';
 
     /**
-     * User agent of the HTTP request, set to "PHP-Swagger" by default
-     *
-     * @var string
-     */
-    protected $userAgent = 'Swagger-Codegen/1.0.0/php';
-
-    /**
      * Debug switch (default set to false)
      *
      * @var bool
@@ -117,6 +113,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = 'sendinblue_clientAPI/v' . $GLOBALS['version'] . '/php'; 
     }
 
     /**
@@ -277,6 +274,12 @@ class Configuration
             throw new \InvalidArgumentException('User-agent must be a string.');
         }
 
+        if(strpos($userAgent, 'sendinblue_') !== false) {
+            if(strpos($userAgent, '#') !== false) {
+                $userAgent = str_replace('#', $GLOBALS['version'], $userAgent);  
+            }
+        }
+
         $this->userAgent = $userAgent;
         return $this;
     }
@@ -370,7 +373,6 @@ class Configuration
         if (self::$defaultConfiguration === null) {
             self::$defaultConfiguration = new Configuration();
         }
-
         return self::$defaultConfiguration;
     }
 

--- a/lib/Model/CreateAttribute.php
+++ b/lib/Model/CreateAttribute.php
@@ -284,7 +284,7 @@ class CreateAttribute implements ModelInterface, ArrayAccess
     /**
      * Sets enumeration
      *
-     * @param \SendinBlue\Client\Model\CreateAttributeEnumeration[] $enumeration List of values and labels that the attribute can take. Use only if the attribute's category is \"category\". For example, `[{\"value\":1, \"label\":\"male\"}, {\"value\":2, \"label\":\"female\"}]`
+     * @param \SendinBlue\Client\Model\CreateAttributeEnumeration[] $enumeration List of values and labels that the attribute can take. Use only if the attribute's category is \"category\". For example, [{\"value\":1, \"label\":\"male\"}, {\"value\":2, \"label\":\"female\"}]
      *
      * @return $this
      */

--- a/lib/Model/CreateContact.php
+++ b/lib/Model/CreateContact.php
@@ -277,7 +277,7 @@ class CreateContact implements ModelInterface, ArrayAccess
     /**
      * Sets attributes
      *
-     * @param object $attributes Pass the set of attributes and their values. These attributes must be present in your SendinBlue account. For eg. `{\"FNAME\":\"Elly\", \"LNAME\":\"Roger\"}`
+     * @param object $attributes Pass the set of attributes and their values. These attributes must be present in your SendinBlue account. For eg. {\"FNAME\":\"Elly\", \"LNAME\":\"Roger\"}
      *
      * @return $this
      */

--- a/lib/Model/CreateEmailCampaign.php
+++ b/lib/Model/CreateEmailCampaign.php
@@ -840,7 +840,7 @@ class CreateEmailCampaign implements ModelInterface, ArrayAccess
     /**
      * Sets params
      *
-     * @param object $params Pass the set of attributes to customize the type classic campaign. For example, `{\"FNAME\":\"Joe\", \"LNAME:\"Doe\"}`. Only available if 'type' is 'classic'. It's considered only if campaign is in New Template Language format. The New Template Language is dependent on the values of 'subject', 'htmlContent/htmlUrl', 'sender.name' & 'toField'
+     * @param object $params Pass the set of attributes to customize the type classic campaign. For example, {\"FNAME\":\"Joe\", \"LNAME\":\"Doe\"}. Only available if 'type' is 'classic'. It's considered only if campaign is in New Template Language format. The New Template Language is dependent on the values of 'subject', 'htmlContent/htmlUrl', 'sender.name' & 'toField'
      *
      * @return $this
      */

--- a/lib/Model/CreateSmtpTemplateSender.php
+++ b/lib/Model/CreateSmtpTemplateSender.php
@@ -202,9 +202,6 @@ class CreateSmtpTemplateSender implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['email'] === null) {
-            $invalidProperties[] = "'email' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetChildDomain.php
+++ b/lib/Model/GetChildDomain.php
@@ -195,12 +195,6 @@ class GetChildDomain implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['domain'] === null) {
-            $invalidProperties[] = "'domain' can't be null";
-        }
-        if ($this->container['active'] === null) {
-            $invalidProperties[] = "'active' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetChildrenList.php
+++ b/lib/Model/GetChildrenList.php
@@ -195,9 +195,6 @@ class GetChildrenList implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['count'] === null) {
-            $invalidProperties[] = "'count' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetEmailCampaign.php
+++ b/lib/Model/GetEmailCampaign.php
@@ -450,14 +450,8 @@ class GetEmailCampaign implements ModelInterface, ArrayAccess
         if ($this->container['replyTo'] === null) {
             $invalidProperties[] = "'replyTo' can't be null";
         }
-        if ($this->container['toField'] === null) {
-            $invalidProperties[] = "'toField' can't be null";
-        }
         if ($this->container['htmlContent'] === null) {
             $invalidProperties[] = "'htmlContent' can't be null";
-        }
-        if ($this->container['tag'] === null) {
-            $invalidProperties[] = "'tag' can't be null";
         }
         if ($this->container['createdAt'] === null) {
             $invalidProperties[] = "'createdAt' can't be null";

--- a/lib/Model/GetEmailCampaigns.php
+++ b/lib/Model/GetEmailCampaigns.php
@@ -195,9 +195,6 @@ class GetEmailCampaigns implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['count'] === null) {
-            $invalidProperties[] = "'count' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetEmailEventReportEvents.php
+++ b/lib/Model/GetEmailEventReportEvents.php
@@ -66,7 +66,8 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         'tag' => 'string',
         'ip' => 'string',
         'link' => 'string',
-        'from' => 'string'
+        'from' => 'string',
+        'templateId' => 'int'
     ];
 
     /**
@@ -84,7 +85,8 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         'tag' => null,
         'ip' => null,
         'link' => null,
-        'from' => 'email'
+        'from' => 'email',
+        'templateId' => 'int64'
     ];
 
     /**
@@ -123,7 +125,8 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         'tag' => 'tag',
         'ip' => 'ip',
         'link' => 'link',
-        'from' => 'from'
+        'from' => 'from',
+        'templateId' => 'templateId'
     ];
 
     /**
@@ -141,7 +144,8 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         'tag' => 'setTag',
         'ip' => 'setIp',
         'link' => 'setLink',
-        'from' => 'setFrom'
+        'from' => 'setFrom',
+        'templateId' => 'setTemplateId'
     ];
 
     /**
@@ -159,7 +163,8 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         'tag' => 'getTag',
         'ip' => 'getIp',
         'link' => 'getLink',
-        'from' => 'getFrom'
+        'from' => 'getFrom',
+        'templateId' => 'getTemplateId'
     ];
 
     /**
@@ -215,6 +220,7 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
     const EVENT_DEFERRED = 'deferred';
     const EVENT_BLOCKED = 'blocked';
     const EVENT_UNSUBSCRIBED = 'unsubscribed';
+    const EVENT_ERROR = 'error';
     
 
     
@@ -238,6 +244,7 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
             self::EVENT_DEFERRED,
             self::EVENT_BLOCKED,
             self::EVENT_UNSUBSCRIBED,
+            self::EVENT_ERROR,
         ];
     }
     
@@ -267,6 +274,7 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
         $this->container['link'] = isset($data['link']) ? $data['link'] : null;
         $this->container['from'] = isset($data['from']) ? $data['from'] : null;
+        $this->container['templateId'] = isset($data['templateId']) ? $data['templateId'] : null;
     }
 
     /**
@@ -558,6 +566,30 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
     public function setFrom($from)
     {
         $this->container['from'] = $from;
+
+        return $this;
+    }
+
+    /**
+     * Gets templateId
+     *
+     * @return int
+     */
+    public function getTemplateId()
+    {
+        return $this->container['templateId'];
+    }
+
+    /**
+     * Sets templateId
+     *
+     * @param int $templateId ID of the template (only available if the email is template based)
+     *
+     * @return $this
+     */
+    public function setTemplateId($templateId)
+    {
+        $this->container['templateId'] = $templateId;
 
         return $this;
     }

--- a/lib/Model/GetExtendedCampaignOverview.php
+++ b/lib/Model/GetExtendedCampaignOverview.php
@@ -438,14 +438,8 @@ class GetExtendedCampaignOverview implements ModelInterface, ArrayAccess
         if ($this->container['replyTo'] === null) {
             $invalidProperties[] = "'replyTo' can't be null";
         }
-        if ($this->container['toField'] === null) {
-            $invalidProperties[] = "'toField' can't be null";
-        }
         if ($this->container['htmlContent'] === null) {
             $invalidProperties[] = "'htmlContent' can't be null";
-        }
-        if ($this->container['tag'] === null) {
-            $invalidProperties[] = "'tag' can't be null";
         }
         if ($this->container['createdAt'] === null) {
             $invalidProperties[] = "'createdAt' can't be null";

--- a/lib/Model/GetFolderLists.php
+++ b/lib/Model/GetFolderLists.php
@@ -195,12 +195,6 @@ class GetFolderLists implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['lists'] === null) {
-            $invalidProperties[] = "'lists' can't be null";
-        }
-        if ($this->container['count'] === null) {
-            $invalidProperties[] = "'count' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetLists.php
+++ b/lib/Model/GetLists.php
@@ -195,12 +195,6 @@ class GetLists implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['lists'] === null) {
-            $invalidProperties[] = "'lists' can't be null";
-        }
-        if ($this->container['count'] === null) {
-            $invalidProperties[] = "'count' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetProcesses.php
+++ b/lib/Model/GetProcesses.php
@@ -195,9 +195,6 @@ class GetProcesses implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['count'] === null) {
-            $invalidProperties[] = "'count' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetSmsCampaign.php
+++ b/lib/Model/GetSmsCampaign.php
@@ -286,9 +286,6 @@ class GetSmsCampaign implements ModelInterface, ArrayAccess
         if ($this->container['content'] === null) {
             $invalidProperties[] = "'content' can't be null";
         }
-        if ($this->container['scheduledAt'] === null) {
-            $invalidProperties[] = "'scheduledAt' can't be null";
-        }
         if ($this->container['sender'] === null) {
             $invalidProperties[] = "'sender' can't be null";
         }

--- a/lib/Model/GetSmsCampaignOverview.php
+++ b/lib/Model/GetSmsCampaignOverview.php
@@ -274,9 +274,6 @@ class GetSmsCampaignOverview implements ModelInterface, ArrayAccess
         if ($this->container['content'] === null) {
             $invalidProperties[] = "'content' can't be null";
         }
-        if ($this->container['scheduledAt'] === null) {
-            $invalidProperties[] = "'scheduledAt' can't be null";
-        }
         if ($this->container['sender'] === null) {
             $invalidProperties[] = "'sender' can't be null";
         }

--- a/lib/Model/GetSmsCampaigns.php
+++ b/lib/Model/GetSmsCampaigns.php
@@ -195,9 +195,6 @@ class GetSmsCampaigns implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['count'] === null) {
-            $invalidProperties[] = "'count' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetSmsEventReportEvents.php
+++ b/lib/Model/GetSmsEventReportEvents.php
@@ -254,18 +254,6 @@ class GetSmsEventReportEvents implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['phoneNumber'] === null) {
-            $invalidProperties[] = "'phoneNumber' can't be null";
-        }
-        if ($this->container['date'] === null) {
-            $invalidProperties[] = "'date' can't be null";
-        }
-        if ($this->container['messageId'] === null) {
-            $invalidProperties[] = "'messageId' can't be null";
-        }
-        if ($this->container['event'] === null) {
-            $invalidProperties[] = "'event' can't be null";
-        }
         $allowedValues = $this->getEventAllowableValues();
         if (!is_null($this->container['event']) && !in_array($this->container['event'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
@@ -381,7 +369,7 @@ class GetSmsEventReportEvents implements ModelInterface, ArrayAccess
     public function setEvent($event)
     {
         $allowedValues = $this->getEventAllowableValues();
-        if (!in_array($event, $allowedValues, true)) {
+        if (!is_null($event) && !in_array($event, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value for 'event', must be one of '%s'",

--- a/lib/Model/GetTransacAggregatedSmsReport.php
+++ b/lib/Model/GetTransacAggregatedSmsReport.php
@@ -243,36 +243,6 @@ class GetTransacAggregatedSmsReport implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['range'] === null) {
-            $invalidProperties[] = "'range' can't be null";
-        }
-        if ($this->container['requests'] === null) {
-            $invalidProperties[] = "'requests' can't be null";
-        }
-        if ($this->container['delivered'] === null) {
-            $invalidProperties[] = "'delivered' can't be null";
-        }
-        if ($this->container['hardBounces'] === null) {
-            $invalidProperties[] = "'hardBounces' can't be null";
-        }
-        if ($this->container['softBounces'] === null) {
-            $invalidProperties[] = "'softBounces' can't be null";
-        }
-        if ($this->container['blocked'] === null) {
-            $invalidProperties[] = "'blocked' can't be null";
-        }
-        if ($this->container['unsubscribed'] === null) {
-            $invalidProperties[] = "'unsubscribed' can't be null";
-        }
-        if ($this->container['replied'] === null) {
-            $invalidProperties[] = "'replied' can't be null";
-        }
-        if ($this->container['accepted'] === null) {
-            $invalidProperties[] = "'accepted' can't be null";
-        }
-        if ($this->container['rejected'] === null) {
-            $invalidProperties[] = "'rejected' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/lib/Model/GetTransacSmsReportReports.php
+++ b/lib/Model/GetTransacSmsReportReports.php
@@ -243,36 +243,6 @@ class GetTransacSmsReportReports implements ModelInterface, ArrayAccess
     {
         $invalidProperties = [];
 
-        if ($this->container['date'] === null) {
-            $invalidProperties[] = "'date' can't be null";
-        }
-        if ($this->container['requests'] === null) {
-            $invalidProperties[] = "'requests' can't be null";
-        }
-        if ($this->container['delivered'] === null) {
-            $invalidProperties[] = "'delivered' can't be null";
-        }
-        if ($this->container['hardBounces'] === null) {
-            $invalidProperties[] = "'hardBounces' can't be null";
-        }
-        if ($this->container['softBounces'] === null) {
-            $invalidProperties[] = "'softBounces' can't be null";
-        }
-        if ($this->container['blocked'] === null) {
-            $invalidProperties[] = "'blocked' can't be null";
-        }
-        if ($this->container['unsubscribed'] === null) {
-            $invalidProperties[] = "'unsubscribed' can't be null";
-        }
-        if ($this->container['replied'] === null) {
-            $invalidProperties[] = "'replied' can't be null";
-        }
-        if ($this->container['accepted'] === null) {
-            $invalidProperties[] = "'accepted' can't be null";
-        }
-        if ($this->container['rejected'] === null) {
-            $invalidProperties[] = "'rejected' can't be null";
-        }
         return $invalidProperties;
     }
 

--- a/test/Api/TransactionalEmailsApiTest.php
+++ b/test/Api/TransactionalEmailsApiTest.php
@@ -72,12 +72,32 @@ class TransactionalEmailsApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test case for blockNewDomain
+     *
+     * Add a new domain to the list of blocked domains.
+     *
+     */
+    public function testBlockNewDomain()
+    {
+    }
+
+    /**
      * Test case for createSmtpTemplate
      *
      * Create an email template.
      *
      */
     public function testCreateSmtpTemplate()
+    {
+    }
+
+    /**
+     * Test case for deleteBlockedDomain
+     *
+     * Unblock an existing domain from the list of blocked domains.
+     *
+     */
+    public function testDeleteBlockedDomain()
     {
     }
 
@@ -108,6 +128,16 @@ class TransactionalEmailsApiTest extends \PHPUnit_Framework_TestCase
      *
      */
     public function testGetAggregatedSmtpReport()
+    {
+    }
+
+    /**
+     * Test case for getBlockedDomains
+     *
+     * Get the list of blocked domains.
+     *
+     */
+    public function testGetBlockedDomains()
     {
     }
 

--- a/test/Model/BlockDomainTest.php
+++ b/test/Model/BlockDomainTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AddContactToListTest
+ * BlockDomainTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * AddContactToListTest Class Doc Comment
+ * BlockDomainTest Class Doc Comment
  *
  * @category    Class
- * @description AddContactToList
+ * @description BlockDomain
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class AddContactToListTest extends \PHPUnit_Framework_TestCase
+class BlockDomainTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,23 +70,16 @@ class AddContactToListTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "AddContactToList"
+     * Test "BlockDomain"
      */
-    public function testAddContactToList()
+    public function testBlockDomain()
     {
     }
 
     /**
-     * Test attribute "emails"
+     * Test attribute "domain"
      */
-    public function testPropertyEmails()
-    {
-    }
-
-    /**
-     * Test attribute "ids"
-     */
-    public function testPropertyIds()
+    public function testPropertyDomain()
     {
     }
 }

--- a/test/Model/GetBlockedDomainsTest.php
+++ b/test/Model/GetBlockedDomainsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AddContactToListTest
+ * GetBlockedDomainsTest
  *
  * PHP version 5
  *
@@ -30,15 +30,15 @@
 namespace SendinBlue\Client;
 
 /**
- * AddContactToListTest Class Doc Comment
+ * GetBlockedDomainsTest Class Doc Comment
  *
  * @category    Class
- * @description AddContactToList
+ * @description list of blocked domains
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen
  */
-class AddContactToListTest extends \PHPUnit_Framework_TestCase
+class GetBlockedDomainsTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -70,23 +70,16 @@ class AddContactToListTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test "AddContactToList"
+     * Test "GetBlockedDomains"
      */
-    public function testAddContactToList()
+    public function testGetBlockedDomains()
     {
     }
 
     /**
-     * Test attribute "emails"
+     * Test attribute "domains"
      */
-    public function testPropertyEmails()
-    {
-    }
-
-    /**
-     * Test attribute "ids"
-     */
-    public function testPropertyIds()
+    public function testPropertyDomains()
     {
     }
 }

--- a/test/Model/GetCampaignStatsTest.php
+++ b/test/Model/GetCampaignStatsTest.php
@@ -159,4 +159,11 @@ class GetCampaignStatsTest extends \PHPUnit_Framework_TestCase
     public function testPropertyDeferred()
     {
     }
+
+    /**
+     * Test attribute "returnBounce"
+     */
+    public function testPropertyReturnBounce()
+    {
+    }
 }

--- a/test/Model/GetEmailEventReportEventsTest.php
+++ b/test/Model/GetEmailEventReportEventsTest.php
@@ -145,4 +145,11 @@ class GetEmailEventReportEventsTest extends \PHPUnit_Framework_TestCase
     public function testPropertyFrom()
     {
     }
+
+    /**
+     * Test attribute "templateId"
+     */
+    public function testPropertyTemplateId()
+    {
+    }
 }

--- a/test/Model/GetExtendedCampaignOverviewTest.php
+++ b/test/Model/GetExtendedCampaignOverviewTest.php
@@ -271,4 +271,11 @@ class GetExtendedCampaignOverviewTest extends \PHPUnit_Framework_TestCase
     public function testPropertySentDate()
     {
     }
+
+    /**
+     * Test attribute "returnBounce"
+     */
+    public function testPropertyReturnBounce()
+    {
+    }
 }

--- a/test/Model/GetSmtpTemplateOverviewTest.php
+++ b/test/Model/GetSmtpTemplateOverviewTest.php
@@ -159,4 +159,11 @@ class GetSmtpTemplateOverviewTest extends \PHPUnit_Framework_TestCase
     public function testPropertyModifiedAt()
     {
     }
+
+    /**
+     * Test attribute "doiTemplate"
+     */
+    public function testPropertyDoiTemplate()
+    {
+    }
 }

--- a/test/Model/PostContactInfoContactsTest.php
+++ b/test/Model/PostContactInfoContactsTest.php
@@ -96,4 +96,11 @@ class PostContactInfoContactsTest extends \PHPUnit_Framework_TestCase
     public function testPropertyTotal()
     {
     }
+
+    /**
+     * Test attribute "processId"
+     */
+    public function testPropertyProcessId()
+    {
+    }
 }

--- a/test/Model/SendSmtpEmailReplyToTest.php
+++ b/test/Model/SendSmtpEmailReplyToTest.php
@@ -33,7 +33,7 @@ namespace SendinBlue\Client;
  * SendSmtpEmailReplyToTest Class Doc Comment
  *
  * @category    Class
- * @description Email (required), along with name (optional), on which transactional mail recipients will be able to reply back. For example, {&#39;email&#39;:&#39;ann6533@example.com&#39;, &#39;name&#39;:&#39;Ann&#39;}.
+ * @description Email (required), along with name (optional), on which transactional mail recipients will be able to reply back. For example, {\&quot;email\&quot;:\&quot;ann6533@example.com\&quot;, \&quot;name\&quot;:\&quot;Ann\&quot;}.
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen

--- a/test/Model/SendSmtpEmailSenderTest.php
+++ b/test/Model/SendSmtpEmailSenderTest.php
@@ -33,7 +33,7 @@ namespace SendinBlue\Client;
  * SendSmtpEmailSenderTest Class Doc Comment
  *
  * @category    Class
- * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass name (optional) and email or id of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
+ * @description Mandatory if &#x60;templateId&#x60; is not passed. Pass &#x60;name&#x60; (optional) and &#x60;email&#x60; OR &#x60;id&#x60; of sender from which emails will be sent. &#x60;name&#x60; will be ignored if passed along with sender &#x60;id&#x60;. For example, {\&quot;name\&quot;:\&quot;Mary from MyShop\&quot;, \&quot;email\&quot;:\&quot;no-reply@myshop.com\&quot;} or {\&quot;id\&quot;:2}
  * @package     SendinBlue\Client
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen

--- a/test/Model/UpdateChildAccountStatusTest.php
+++ b/test/Model/UpdateChildAccountStatusTest.php
@@ -96,4 +96,11 @@ class UpdateChildAccountStatusTest extends \PHPUnit_Framework_TestCase
     public function testPropertyMarketingAutomation()
     {
     }
+
+    /**
+     * Test attribute "smsCampaign"
+     */
+    public function testPropertySmsCampaign()
+    {
+    }
 }


### PR DESCRIPTION
- Sorting order implemented for routes (`Processes`, `emailCampaigns`, `Webhooks`, `smsCampaigns`, `transactionalEmails`, `transactionalSms`)
- Blocked domains functionality implemented
- Added error event in response schema of `getEmailEventReport` 
- Unnecessary fields from swagger file that were initially marked as `required`, are now marked as `optional`- Fix in sorting order in case of marketing events
- Fix in `get-reports` route when passing `startDate` and `endDate`
- Return `contact ID` in webhook if ID is used in add/remove contact
- `getFolders` and `getFoldersLists` count issues fixed
- Add `templateId` to response in `getEmailEventReport`