### PR TITLE
Update CreateContact.php for PHP 8.1

### DIFF
--- a/lib/Model/CreateContact.php
+++ b/lib/Model/CreateContact.php
@@ -414,7 +414,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset):bool
     {
         return isset($this->container[$offset]);
     }

--- a/lib/Model/CreateContact.php
+++ b/lib/Model/CreateContact.php
@@ -439,7 +439,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value):void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -455,7 +455,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset):void
     {
         unset($this->container[$offset]);
     }

--- a/lib/Model/CreateContact.php
+++ b/lib/Model/CreateContact.php
@@ -426,7 +426,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset):mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -465,7 +465,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      *
      * @return string
      */
-    public function __toString()
+    public function __toString():string
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
             return json_encode(

--- a/lib/Model/CreateUpdateContactModel.php
+++ b/lib/Model/CreateUpdateContactModel.php
@@ -246,7 +246,7 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset):mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }

--- a/lib/Model/CreateUpdateContactModel.php
+++ b/lib/Model/CreateUpdateContactModel.php
@@ -234,7 +234,7 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset):bool
     {
         return isset($this->container[$offset]);
     }
@@ -259,7 +259,7 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value):void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -275,7 +275,7 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset):void
     {
         unset($this->container[$offset]);
     }


### PR DESCRIPTION
Return type of SendinBlue\Client\Model\CreateContact::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice