### PR TITLE
Set default limit value equal to max limit value

### DIFF
--- a/lib/Api/EmailCampaignsApi.php
+++ b/lib/Api/EmailCampaignsApi.php
@@ -1537,7 +1537,7 @@ class EmailCampaignsApi
      * @param  string $status Filter on the status of the campaign (optional)
      * @param  string $startDate Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
      * @param  string $endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) (optional)
-     * @param  int $limit Number of documents per page (optional, default to 500)
+     * @param  int $limit Number of documents per page (optional, default to 100, max value is 100)
      * @param  int $offset Index of the first document in the page (optional, default to 0)
      * @param  string $sort Sort the results in the ascending/descending order of record creation. Default order is **descending** if &#x60;sort&#x60; is not passed (optional, default to desc)
      *
@@ -1545,7 +1545,7 @@ class EmailCampaignsApi
      * @throws \InvalidArgumentException
      * @return \SendinBlue\Client\Model\GetEmailCampaigns
      */
-    public function getEmailCampaigns($type = null, $status = null, $startDate = null, $endDate = null, $limit = '500', $offset = '0', $sort = 'desc')
+    public function getEmailCampaigns($type = null, $status = null, $startDate = null, $endDate = null, $limit = '100', $offset = '0', $sort = 'desc')
     {
         list($response) = $this->getEmailCampaignsWithHttpInfo($type, $status, $startDate, $endDate, $limit, $offset, $sort);
         return $response;


### PR DESCRIPTION
As for this closed [issue](https://github.com/sendinblue/APIv3-php-library/issues/223) (not resolved). I've created the pull-request with the change to the default limit value (500 previously) of the "Number of documents per page" matching the max limit value (100 - as mentioned in the issue). Without this change we got an error as the default value exceeds the max value.