### PR TITLE
Issue #147 - Remove usage of parent:: in classes without parent class.

### DIFF
--- a/lib/Model/AbTestVersionClicks.php
+++ b/lib/Model/AbTestVersionClicks.php
@@ -187,9 +187,7 @@ class AbTestVersionClicks implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/CompanyAttributes.php
+++ b/lib/Model/CompanyAttributes.php
@@ -187,9 +187,7 @@ class CompanyAttributes implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/DealAttributes.php
+++ b/lib/Model/DealAttributes.php
@@ -187,9 +187,7 @@ class DealAttributes implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/FileList.php
+++ b/lib/Model/FileList.php
@@ -187,9 +187,7 @@ class FileList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/GetChildDomains.php
+++ b/lib/Model/GetChildDomains.php
@@ -186,9 +186,7 @@ class GetChildDomains implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/GetStatsByBrowser.php
+++ b/lib/Model/GetStatsByBrowser.php
@@ -186,9 +186,7 @@ class GetStatsByBrowser implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/GetStatsByDomain.php
+++ b/lib/Model/GetStatsByDomain.php
@@ -186,9 +186,7 @@ class GetStatsByDomain implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**

--- a/lib/Model/NoteList.php
+++ b/lib/Model/NoteList.php
@@ -187,9 +187,7 @@ class NoteList implements ModelInterface, ArrayAccess
      */
     public function listInvalidProperties()
     {
-        $invalidProperties = parent::listInvalidProperties();
-
-        return $invalidProperties;
+        return [];
     }
 
     /**


### PR DESCRIPTION
Hi everyone,

Here is a quick fix to remove deprecation warnings and errors on PHP8, related to #147 and https://www.drupal.org/project/sendinblue/issues/3331359 and https://www.drupal.org/project/sendinblue/issues/3178804#comment-14913517

Best regards,
Bastien