### PR TITLE
Fix issue with empty response

### DIFF
--- a/lib/Api/ContactsApi.php
+++ b/lib/Api/ContactsApi.php
@@ -4107,6 +4107,7 @@ class ContactsApi
             if ($returnType === '\SplFileObject') {
                 $content = $responseBody; //stream goes to serializer
             } else {
+                $responseBody->rewind();
                 $content = $responseBody->getContents();
                 if ($returnType !== 'string') {
                     $content = json_decode($content);


### PR DESCRIPTION
While using `getContactsFromList` function there is a way that stream responses with null data - more info about can be found here https://stackoverflow.com/a/60510193